### PR TITLE
Multiple trial

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -297,7 +297,11 @@ GENERALIZE:
       TRUE_POSITIVES: 1
       FALSE_NEGATIVES: 1
       FALSE_POSITIVES: 1
+      SENSITIVITY: 90.1
+      SPECIFICITY: 79.3
     CROSS_VAL:
       SPLIT: 0.1  # Specify the train-val data split for each fine-tune run.
       RUNS: 2
       EPOCHS: 1
+    LAZY: True # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
+    # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.

--- a/config.yml
+++ b/config.yml
@@ -23,6 +23,8 @@ PREPROCESS:
     WINDOW_SECONDS: 3 # Mini-clip length measured in seconds
     IMG_SIZE: [224, 224]  # (Height, Width) of final miniclips.
     BASE_FR: 30  # Base frame rate - videos are downsampled to this.
+    DB_TABLE: 'clips_chile'  # Name of the table in the database from which to pull clips.
+
 
   # The paths to save files. After running the preprocess pipeline, the npzs and csvs are usually all that are needed to train.
   # You shouldn't *have* to edit these, as they are stored as relative and not absolute paths.

--- a/config.yml
+++ b/config.yml
@@ -280,7 +280,7 @@ GENERALIZE:
     EXPERIMENTS: 'C:/Users/hsmle/Documents/Deep_Breathe/lung-sliding-classifier/generalizability/results/experiments'
     TRIALS: 'C:/Users/hsmle/Documents/Deep_Breathe/lung-sliding-classifier/generalizability/results/trials'
   FOLD_SAMPLE:
-    SEED: 42069  # Seed number for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
+    SEED: [42069, 42070, 42071, 42072, 42073]  # Seed number for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     OVERWRITE_FOLDER: True  # Set this to True if you want to overwrite existing fold .txt files.
     NUM_FOLDS: 5  # Number of desired external patient slices for augmenting training data during fine-tuning.
   FINETUNE:

--- a/config.yml
+++ b/config.yml
@@ -27,12 +27,12 @@ PREPROCESS:
   # The paths to save files. After running the preprocess pipeline, the npzs and csvs are usually all that are needed to train.
   # You shouldn't *have* to edit these, as they are stored as relative and not absolute paths.
   PATHS:
-    UNMASKED_VIDEOS: 'C:\Users\hsmle\Documents\Deep_Breathe\results/data\raw_videos/'  # Path to the videos that are downloaded from the dataset and stored without transformation.
-    MASKED_VIDEOS: 'C:\Users\hsmle\Documents\Deep_Breathe\lung-sliding-classifier\results/data\masked_videos/'  # Path to the videos that result from running the masking tool on UNMASKED_VIDEOS.
+    UNMASKED_VIDEOS: 'C:\Users\hsmle\Documents\Deep_Breathe\lung-sliding-classifier\generalizability\raw_videos/chile'  # Path to the videos that are downloaded from the dataset and stored without transformation.
+    MASKED_VIDEOS: 'C:\Users\hsmle\Documents\Deep_Breathe\lung-sliding-classifier\generalizability\masked_videos\chile/'  # Path to the videos that result from running the masking tool on UNMASKED_VIDEOS.
     SMOOTHED_VIDEOS: 'C:\Users\hsmle\Documents\Deep_Breathe\lung-sliding-classifier\results/data\smoothed_videos/'  # Path to the videos that result from applying a median filter to MASKED_VIDEOS (optional).
     FLOW_VIDEOS: 'flow_videos/'   # Path to the optical flow video frames (optional).
-    CSVS_OUTPUT: 'C:\Users\hsmle\Documents\Deep_Breathe\lung-sliding-classifier\results/data\csvs\'  # Path to any CSVs that are generated / taken from the database.
-    NPZ: 'C:\Users\hsmle\Documents\Deep_Breathe\lung-sliding-classifier\results/data\npzs\'  # Path to the mini-clip videos.
+    CSVS_OUTPUT: 'C:\Users\hsmle\Documents\Deep_Breathe\lung-sliding-classifier\generalizability\csvs\chile'  # Path to any CSVs that are generated / taken from the database.
+    NPZ: 'C:\Users\hsmle\Documents\Deep_Breathe\lung-sliding-classifier\generalizability\npzs\chile'  # Path to the mini-clip videos.
     FLOW_NPZ: 'flow_npzs/'  # Path to the .npzs containing optical flow mini-clips.
     MASKING_TOOL: 'C:\Users\hsmle\Documents\Deep_Breathe\lung-sliding-classifier\results\data\auto_masking_deeper.h5'  # Path to the masking tool. Currently only works with the older version!!!
 
@@ -189,7 +189,7 @@ TRAIN:
 
   # Path variables involving the training process
   PATHS:
-    CSVS: 'C:/Users/hsmle/Documents/Deep_Breathe/lung-sliding-classifier/results/data/csvs_split/'  # Path for CSVs describing the splits of the dataset
+    CSVS: 'C:/Users/hsmle/Documents/Deep_Breathe/lung-sliding-classifier/generalizability/csvs_split/chile'  # Path for CSVs describing the splits of the dataset
     MODEL_OUT: 'C:/Users/hsmle/Documents/Deep_Breathe/lung-sliding-classifier/results/models/efficientnet/'  # Path where the trained model is saved
     TENSORBOARD: '../results/logs/fit/'  # Path where the tensorboard logs are stored
     EXPERIMENTS: '../results/experiments/'
@@ -271,7 +271,7 @@ GENERALIZE:
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
-    MMODES: 'C:\\Users\\hsmle\\Documents\\Deep_Breathe\\lung-sliding-classifier\\generalizability\\mmodes'  # Path to external data M-mode images.
+    MMODES: 'C:/Users/hsmle/Documents/Deep_Breathe/lung-sliding-classifier/generalizability/mmodes'  # Path to external data M-mode images.
     CSV_OUT: 'C:/Users/hsmle/Documents/Deep_Breathe/lung-sliding-classifier/generalizability/csvs'  # Path to external data csvs.
     MODEL_OUT: 'C:/Users/hsmle/Documents/Deep_Breathe/lung-sliding-classifier/generalizability/results/models'  # Path to fine-tuned models.
     FOLDS: 'C:/Users/hsmle/Documents/Deep_Breathe/lung-sliding-classifier/generalizability/folds'  # Path to external data patient-wise fold .txt files.
@@ -286,7 +286,7 @@ GENERALIZE:
   FINETUNE:
     MODEL_DEF: 'efficientnet'  # Set this equal to the model definition string used for the pre-trained model.
     OVERWRITE_MODEL_DIR: True  # Set True if you want to clear existing contents in the model folder.
-    METRIC_THRESHOLDS:  # Thresholds for assessing the performance of a fine-tunend model.
+    METRIC_THRESHOLDS:  # Thresholds for assessing the performance of a fine-tuned model.
       ACCURACY: 0.9
       AUC: 1
       PRECISION: 1

--- a/config.yml
+++ b/config.yml
@@ -268,6 +268,7 @@ EXPLAINABILITY:
 GENERALIZE:
   LOCATIONS: ['chile', 'ottawa']  # List of centers involved in the multi-center study.
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
+  NUM_TRIALS: 3  # Specify the number of fine-tuning trials.
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
@@ -297,6 +298,6 @@ GENERALIZE:
       FALSE_NEGATIVES: 1
       FALSE_POSITIVES: 1
     CROSS_VAL:
-      SPLIT: 0.1
+      SPLIT: 0.1  # Specify the train-val data split for each fine-tune run.
       RUNS: 2
       EPOCHS: 1

--- a/config.yml
+++ b/config.yml
@@ -265,7 +265,7 @@ EXPLAINABILITY:
     MODEL: 'results/models/efficientnet/20220325-190905'  # Trained model used to generate heatmaps.
     FEATURE_HEATMAPS: 'feature_heatmaps/'  # Output directory for heatmap videos.
 
-GENERALIZE:
+EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa']  # List of centers involved in the multi-center study.
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
   NUM_TRIALS: 3  # Specify the number of fine-tuning trials.

--- a/config.yml
+++ b/config.yml
@@ -289,16 +289,10 @@ GENERALIZE:
     MODEL_DEF: 'efficientnet'  # Set this equal to the model definition string used for the pre-trained model.
     OVERWRITE_MODEL_DIR: True  # Set True if you want to clear existing contents in the model folder.
     METRIC_THRESHOLDS:  # Thresholds for assessing the performance of a fine-tuned model.
-      ACCURACY: 0.9
-      AUC: 1
-      PRECISION: 1
-      RECALL: 1
-      TRUE_NEGATIVES: 1
-      TRUE_POSITIVES: 1
-      FALSE_NEGATIVES: 1
-      FALSE_POSITIVES: 1
-      SENSITIVITY: 90.1
-      SPECIFICITY: 79.3
+      LOWER_BOUNDS:
+        SENSITIVITY: 90.1
+        SPECIFICITY: 79.3
+      UPPER_BOUNDS:
     CROSS_VAL:
       SPLIT: 0.1  # Specify the train-val data split for each fine-tune run.
       RUNS: 2

--- a/config.yml
+++ b/config.yml
@@ -280,7 +280,8 @@ GENERALIZE:
     EXPERIMENTS: 'C:/Users/hsmle/Documents/Deep_Breathe/lung-sliding-classifier/generalizability/results/experiments'
     TRIALS: 'C:/Users/hsmle/Documents/Deep_Breathe/lung-sliding-classifier/generalizability/results/trials'
   FOLD_SAMPLE:
-    SEED: [42069, 42070, 42071, 42072, 42073]  # Seed number for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
+    SEED: [42069, 42070, 42071, 42072, 42073]  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
+    # There is one seed for each trial; insert or remove (or change) seeds as necessary/desired.
     OVERWRITE_FOLDER: True  # Set this to True if you want to overwrite existing fold .txt files.
     NUM_FOLDS: 5  # Number of desired external patient slices for augmenting training data during fine-tuning.
   FINETUNE:

--- a/src/data/download_videos.py
+++ b/src/data/download_videos.py
@@ -88,8 +88,8 @@ cnx = mysql.connector.connect(user=USERNAME, password=PASSWORD,
 
 # Query Database for sliding and no_sliding labeled data but excluding significant probe movement and B lines
 # and pleural effusion or consolidation
-sliding_df = get_clips_from_db(location='chile', sliding=True)
-no_sliding_df = get_clips_from_db(location='chile', sliding=-False)
+sliding_df = get_clips_from_db(cfg['PARAMS']['DB_TABLE'], sliding=True)
+no_sliding_df = get_clips_from_db(cfg['PARAMS']['DB_TABLE'], sliding=-False)
 
 # sliding_df = pd.read_sql('''select * from clips_chile where view='parenchymal' and a_or_b_lines='a_lines'
 #                               and (quality NOT LIKE '%significant_probe_movement%' or quality is null)

--- a/src/data/download_videos.py
+++ b/src/data/download_videos.py
@@ -7,8 +7,8 @@ import cv2
 from utils import refresh_folder
 
 # Load dictionary of constants stored in config.yml & db credentials in database_config.yml
-cfg = yaml.full_load(open(os.path.join(os.getcwd(), "../../config.yml"), 'r'))['PREPROCESS']
-database_cfg = yaml.full_load(open(os.path.join(os.getcwd(), "../../database_config.yml"), 'r'))
+cfg = yaml.full_load(open(os.path.join(os.getcwd(), "..\\..\\config.yml"), 'r'))['PREPROCESS']
+database_cfg = yaml.full_load(open(os.path.join(os.getcwd(), "..\\..\\database_config.yml"), 'r'))
 
 
 def download(df, sliding, fr_rows, video_out_root_folder=cfg['PATHS']['UNMASKED_VIDEOS'],
@@ -62,7 +62,8 @@ def download(df, sliding, fr_rows, video_out_root_folder=cfg['PATHS']['UNMASKED_
     # Iterate through df to download the videos and preserve their id in the name
     for index, row in df.iterrows():
         out_path = video_out_folder + row['id'] + '.mp4'
-        urllib.request.urlretrieve(row['s3_path'], out_path)
+        row_no_whitespace = row['s3_path'].replace(' ', '%20')
+        urllib.request.urlretrieve(row_no_whitespace, out_path)
 
         # Get frame rate
         cap = cv2.VideoCapture(out_path)
@@ -86,37 +87,31 @@ cnx = mysql.connector.connect(user=USERNAME, password=PASSWORD,
 
 # Query Database for sliding and no_sliding labeled data but excluding significant probe movement and B lines
 # and pleural effusion or consolidation
-sliding_df = pd.read_sql('''SELECT * FROM clips WHERE (pleural_line_findings is null OR
-                            pleural_line_findings='thickened') AND (quality NOT LIKE '%significant_probe_movement%' OR
-                            quality is null) AND (a_or_b_lines='a_lines' OR a_or_b_lines='non_a_non_b' 
-                            OR a_or_b_lines is null) AND (pleural_effusion is null) AND (consolidation is null) 
-                            and labelled = 1 and view = 'parenchymal';''', cnx)
-no_sliding_df = pd.read_sql('''SELECT * FROM clips WHERE (pleural_line_findings='absent_lung_sliding' OR
-                               pleural_line_findings='thickened|absent_lung_sliding') AND
-                               (quality NOT LIKE '%significant_probe_movement%' OR quality is null) AND 
-                               (a_or_b_lines='a_lines' OR a_or_b_lines='non_a_non_b' OR a_or_b_lines is null)
-                                AND (pleural_effusion is null) AND (consolidation is null) and 
-                                labelled = 1 and view = 'parenchymal';''', cnx)
+sliding_df = pd.read_sql('''select * from clips_chile where view='parenchymal' and a_or_b_lines='a_lines'
+                              and (quality NOT LIKE '%significant_probe_movement%' or quality is null)
+ and (pleural_line_findings='' or pleural_line_findings='thickened');''', cnx)
+no_sliding_df = pd.read_sql('''select * from clips_chile where view='parenchymal' and a_or_b_lines='a_lines'
+                              and (quality NOT LIKE '%significant_probe_movement%' or quality is null)
+ and (pleural_line_findings = 'absent_lung_sliding');''', cnx)
 
 # Query database for extra negative examples from sprints
-no_sliding_extra_df = pd.read_sql('''SELECT * FROM clips WHERE (pleural_line_findings='absent_lung_sliding'
+no_sliding_extra_df = pd.read_sql('''SELECT * FROM clips_chile WHERE (pleural_line_findings='absent_lung_sliding'
                                       OR pleural_line_findings='thickened|absent_lung_sliding') AND
-                               (quality NOT LIKE '%significant_probe_movement%' OR quality is null) AND 
-                               (a_or_b_lines='a_lines' OR a_or_b_lines='non_a_non_b' OR a_or_b_lines is null) AND 
-                               (pleural_effusion is null) AND (consolidation is null) AND 
-                               labelbox_project_number LIKE 'Lung sliding sprint%';''', cnx)
+                               (quality NOT LIKE '%significant_probe_movement%' OR quality is null) AND
+                               (a_or_b_lines='a_lines' OR a_or_b_lines='non_a_non_b' OR a_or_b_lines is null) AND
+                               (pleural_effusion is null) AND (consolidation is null);''', cnx)
 
-# load extra infusion of sliding clips
-sliding_extra_df = pd.read_csv(os.path.join(cfg['PATHS']['CSVS_OUTPUT'], 'sliding_extra.csv'))
-
-# Load examples that must be excluded from negative class (bad clips)
-bad_sliding_df = pd.read_csv(os.path.join(cfg['PATHS']['CSVS_OUTPUT'], 'sliding_bad_ids.csv'))
-bad_no_sliding_df = pd.read_csv(os.path.join(cfg['PATHS']['CSVS_OUTPUT'], 'no_sliding_bad_ids.csv'))
-
-no_sliding_df = pd.concat([no_sliding_df, no_sliding_extra_df]).reset_index(drop=True)
-sliding_df = pd.concat([sliding_df, sliding_extra_df]).reset_index(drop=True)
-sliding_df = sliding_df[~sliding_df['id'].isin(bad_sliding_df['id'])]
-no_sliding_df = no_sliding_df[~no_sliding_df['id'].isin(bad_no_sliding_df['id'])]
+# # load extra infusion of sliding clips
+# sliding_extra_df = pd.read_csv(os.path.join(cfg['PATHS']['CSVS_OUTPUT'], 'sliding_extra.csv'))
+#
+# # Load examples that must be excluded from negative class (bad clips)
+# bad_sliding_df = pd.read_csv(os.path.join(cfg['PATHS']['CSVS_OUTPUT'], 'sliding_bad_ids.csv'))
+# bad_no_sliding_df = pd.read_csv(os.path.join(cfg['PATHS']['CSVS_OUTPUT'], 'no_sliding_bad_ids.csv'))
+#
+# no_sliding_df = pd.concat([no_sliding_df, no_sliding_extra_df]).reset_index(drop=True)
+# sliding_df = pd.concat([sliding_df, sliding_extra_df]).reset_index(drop=True)
+# sliding_df = sliding_df[~sliding_df['id'].isin(bad_sliding_df['id'])]
+# no_sliding_df = no_sliding_df[~no_sliding_df['id'].isin(bad_no_sliding_df['id'])]
 
 # If we're just asking the amount of videos available, the program will terminate after logging this information
 AMOUNT_ONLY = cfg['PARAMS']['AMOUNT_ONLY']

--- a/src/data/mask.py
+++ b/src/data/mask.py
@@ -4,7 +4,7 @@ from utils import refresh_folder
 from shutil import rmtree
 
 # Load dictionary of constants stored in config.yml
-cfg = yaml.full_load(open(os.path.join(os.getcwd(),"../../config.yml"), 'r'))['PREPROCESS']
+cfg = yaml.full_load(open(os.path.join(os.getcwd(),"..\\..\\config.yml"), 'r'))['PREPROCESS']
 
 # Obtain input folder paths where the downloaded videos are stored
 unmasked_folder = cfg['PATHS']['UNMASKED_VIDEOS']

--- a/src/data/save_m_modes.py
+++ b/src/data/save_m_modes.py
@@ -33,12 +33,12 @@ def save_m_modes(src, dest):
             cv2.imwrite(os.path.join(mmode_class_dir, npz[:-4]) + '.jpg', arr)
 
 
-def length(video):
+def get_clip_length(video_path):
     '''
     Returns the length of an .mp4 video file (in seconds).
     :param video: name of .mp4 file.
     '''
-    cap = cv2.VideoCapture(video)
+    cap = cv2.VideoCapture(video_path)
     fps = cap.get(cv2.CAP_PROP_FPS)
     frame_ct = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
     duration = frame_ct / fps
@@ -52,7 +52,7 @@ if __name__ == '__main__':
         clip_class_dir = os.path.join(raw_clips_dir, clip_class)
         for clip in os.listdir(clip_class_dir):
             # Get clip length.
-            l = length(os.path.join(clip_class_dir, clip))
+            l = get_clip_length(os.path.join(clip_class_dir, clip))
             if l < 3.0:
                 short_clips.append(os.path.join(clip_class_dir, clip))
     # Show the filenames of all clips less than the mini-clip window specified in the config file.

--- a/src/data/save_m_modes.py
+++ b/src/data/save_m_modes.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import yaml
 import cv2
+from utils import refresh_folder
 
 cfg = yaml.full_load(open(os.path.join(os.getcwd(), "..\\..\\config.yml"), 'r'))['PREPROCESS']
 cfg_full = yaml.full_load(open(os.path.join(os.getcwd(), "..\\..\\config.yml"), 'r'))
@@ -11,6 +12,9 @@ npz_dir = cfg['PATHS']['NPZ']
 
 if not os.path.exists(mmode_dir):
     os.makedirs(mmode_dir)
+
+if cfg_full['GENERALIZE']['REFRESH_FOLDERS']:
+    refresh_folder(mmode_dir)
 
 
 def save_m_modes(src, dest):

--- a/src/data/save_m_modes.py
+++ b/src/data/save_m_modes.py
@@ -36,7 +36,7 @@ def save_m_modes(src, dest):
 def length(video):
     '''
     Returns the length of an .mp4 video file (in seconds).
-    :param video: .mp4 file.
+    :param video: name of .mp4 file.
     '''
     cap = cv2.VideoCapture(video)
     fps = cap.get(cv2.CAP_PROP_FPS)

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -115,7 +115,7 @@ class TAAFT:
         Samples external data in self.clip_df into self.k folds. Preserves ratio of positive to negative classes in each fold.
         Folds are saved in a .txt file, where each fold is identified with an integer index, followed by each patient id
         in the fold on a new line.
-        :param trial_folder: name of folder in which to place patient folds. Corresponds to a particular trial.
+        :param trial_folder: full path to folder in which to place patient folds. Corresponds to a particular trial.
         '''
         sliding_df = self.clip_df[self.clip_df['pleural_line_findings'] != 'absent_lung_sliding']
         no_sliding_df = self.clip_df[self.clip_df['pleural_line_findings'] == 'absent_lung_sliding']
@@ -223,7 +223,7 @@ class TAAFT:
         '''
         Performs a single fine-tuning trial. Fine-tunes a model on external clip data, repeatedly augmenting external
         data slices to a training set until all external data has been used for training.
-        :param trial_folder: specifies folder in which to place metrics for current trial.
+        :param trial_folder: full path to folder in which to place metrics for current trial.
         :param hparams: Specifies the set of hyperparameters for fine-tuning the model.
         '''
 

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -487,13 +487,13 @@ class TAAFT:
         else:
             refresh_folder(trial_path)
         for trial in range(n_trials):
-            CUR_TRIAL_DIR = os.path.join(trial_path, 'trial_{}'.format(trial + 1))
-            if not os.path.exists(CUR_TRIAL_DIR):
-                os.makedirs(CUR_TRIAL_DIR)
+            cur_trial_dir = os.path.join(trial_path, 'trial_{}'.format(trial + 1))
+            if not os.path.exists(cur_trial_dir):
+                os.makedirs(cur_trial_dir)
             else:
-                refresh_folder(CUR_TRIAL_DIR)
-            self.sample_folds(CUR_TRIAL_DIR)
-            self.finetune_single_trial(CUR_TRIAL_DIR)
+                refresh_folder(cur_trial_dir)
+            self.sample_folds(cur_trial_dir)
+            self.finetune_single_trial(cur_trial_dir)
 
 
 if __name__ == '__main__':
@@ -524,4 +524,4 @@ if __name__ == '__main__':
     print("All external clips consolidated into", external_df_path, '\n')
     # Construct a TAAFT instance with the dataframe.
     taaft = TAAFT(external_df, 5)
-    taaft.finetune_multiple_trials(3)
+    taaft.finetune_multiple_trials(cfg['GENERALIZE']['NUM_TRIALS'])

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -123,7 +123,8 @@ class TAAFT:
         print("{} unique no-sliding patient ids found.\n".format(len(no_sliding_ids)))
 
         # Shuffle the patient ids.
-        np.random.seed(cfg_full['GENERALIZE']['FOLD_SAMPLE']['SEED'])
+        seed_num = int(trial_folder[-1])
+        np.random.seed(cfg_full['GENERALIZE']['FOLD_SAMPLE']['SEED'][seed_num - 1])
         np.random.shuffle(sliding_ids)
         np.random.shuffle(no_sliding_ids)
 

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -243,12 +243,13 @@ class TAAFT:
 
         print("Sampling complete with seed = " + str(cfg['FOLD_SAMPLE']['SEED']) + ". Folds saved to " + folds_path + ".")
 
-    def finetune_single_trial(self, trial_folder, hparams=None):
+    def finetune_single_trial(self, trial_folder, hparams=None, lazy=True):
         '''
         Performs a single fine-tuning trial. Fine-tunes a model on external clip data, repeatedly augmenting external
         data slices to a training set until all external data has been used for training.
         :param trial_folder: full path to folder in which to place metrics for current trial.
         :param hparams: Specifies the set of hyperparameters for fine-tuning the model.
+        :param lazy: When True, trial will terminate once model performance exceeds minimum thresholds.
         '''
 
         print('Reading values from the config file...')
@@ -361,7 +362,8 @@ class TAAFT:
                 print('Model performance ok. Saving model...')
                 model.save(os.path.join(model_out_dir, add_date_to_filename('finetuned_model') + '.pb'))
                 write_folds_to_txt(add_set, cfg['PATHS']['FOLDS_USED'])
-                continue
+                if lazy:  # if we want trial to end once model performance exceeds thresholds
+                    break
 
             # Set aside some external data to be added to the existing training data.
             add_set = fold_list[num_folds_added]
@@ -517,7 +519,7 @@ class TAAFT:
             else:
                 refresh_folder(cur_trial_dir)
             self.sample_folds(cur_trial_dir)
-            self.finetune_single_trial(cur_trial_dir)
+            self.finetune_single_trial(cur_trial_dir, lazy=cfg['FINETUNE']['LAZY'])
 
 
 if __name__ == '__main__':

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -348,7 +348,7 @@ class TAAFT:
             train_df.sample(frac=1)
             print('Training clips: {}\nValidation clips: {}'.format(len(train_df), len(ext_df)))
 
-            # Create training and validation sets for fine-tune cross-validation.
+            # Create training and validation sets for fine-tuning.
             k = self.k
             val_num = len(train_df) // k
             train_folds = []
@@ -356,12 +356,12 @@ class TAAFT:
             while i < len(train_df):
                 train_folds.append(train_df[i:i + min(len(train_df) - i, val_num)])
                 i += val_num
-            print("{} folds ready for cross-val.".format(len(train_folds)))
+            print("{} folds ready.".format(len(train_folds)))
 
-            # Cross-validation for model fine-tuning.
-            print('Fine-tune cross-validation commencing...')
+            # Model fine-tuning.
+            print('Fine-tuning...')
             for cv_run in range(k):
-                # pick up training from where it left off at the end of previous cross val run.
+                # pick up training from where it left off at the end of previous fine-tuning run.
                 if cv_run > 0:
                     prev_model_path = os.path.join(cfg['PATHS']['MODEL_OUT'], os.listdir(cfg['PATHS']['MODEL_OUT'])[-1])
                 # for run 0 of cross val, retrieve the model from its location immediately after initial training.
@@ -372,13 +372,13 @@ class TAAFT:
 
                 print('FINE-TUNING MODEL FOR FOLD ' + str(cv_run) + ' OF EXTERNAL CLIP TRAINING SET')
 
-                # Set up the train and holdout for each cross-validation run. Note that both parts are taken from the
+                # Set up the train and holdout. Note that both parts are taken from the
                 # external data set aside for training. We have a separate dataframe to store testing data.
                 df_val_part = train_folds[cv_run]
                 df_train_part = train_df[~train_df.isin(df_val_part['patient_id'].unique())]
 
                 # The following code was borrowed from src/models/models.py.
-                # Fine-tune the model with a cross-validation run
+                # Fine-tune the model
                 model_def_fn, preprocessing_fn = get_model(cfg['FINETUNE']['MODEL_DEF'])
 
                 # Prepare the training and validation sets from the dataframes.

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -80,16 +80,16 @@ def check_performance(df):
 
     :return: Bool, whether metrics in df exceed minimum performance thresholds.
     '''
-    # Return false if values less than these thresholds
-    lower_bounds = ['accuracy', 'auc', 'recall', 'precision', 'true_negatives', 'true_positives']
-    # Return false if values greater than these thresholds
-    upper_bounds = ['false_negatives', 'true_positives']
+    cfg_thresh = cfg['FINETUNE']['METRIC_THRESHOLDS']
 
-    for thresh in lower_bounds:
-        if df[thresh].values[0] < cfg['FINETUNE']['METRIC_THRESHOLDS'][thresh.upper()]:
+    # Check that metrics exceed lower bounds, if they exist
+    for thresh in cfg_thresh['LOWER_BOUNDS']:
+        if df[thresh.lower()].values[0] < cfg_thresh[thresh]:
             return False
-    for thresh in upper_bounds:
-        if df[thresh].values[0] > cfg['FINETUNE']['METRIC_THRESHOLDS'][thresh.upper()]:
+
+    # Check that metrics do not exceed upper bounds, if they exist
+    for thresh in cfg_thresh['UPPER_BOUNDS']:
+        if df[thresh.lower()].values[0] > cfg_thresh[thresh]:
             return False
 
     return True

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -22,7 +22,7 @@ from tensorflow_addons.losses import SigmoidFocalCrossEntropy
 
 # cfg refers to the subdictionary of the config file pertaining to our fine-tuning experiments. cfg_full is the entire
 # loaded config file.
-cfg = yaml.full_load(open(os.path.join(os.getcwd(), "config.yml"), 'r'))['GENERALIZE']
+cfg = yaml.full_load(open(os.path.join(os.getcwd(), "config.yml"), 'r'))['EXTERNAL_VAL']
 cfg_full = yaml.full_load(open(os.path.join(os.getcwd(), "config.yml"), 'r'))
 
 
@@ -153,7 +153,7 @@ class TAAFT:
 
         # Shuffle the patient ids.
         seed_num = int(trial_folder[-1])
-        np.random.seed(cfg_full['GENERALIZE']['FOLD_SAMPLE']['SEED'][seed_num - 1])
+        np.random.seed(cfg['FOLD_SAMPLE']['SEED'][seed_num - 1])
         np.random.shuffle(sliding_ids)
         np.random.shuffle(no_sliding_ids)
 
@@ -532,5 +532,5 @@ if __name__ == '__main__':
     external_df = get_external_clip_df()
 
     # Construct a TAAFT instance with the dataframe.
-    taaft = TAAFT(external_df, cfg['GENERALIZE']['FOLD_SAMPLE']['NUM_FOLDS'])
-    taaft.finetune_multiple_trials(cfg['GENERALIZE']['NUM_TRIALS'])
+    taaft = TAAFT(external_df, cfg['FOLD_SAMPLE']['NUM_FOLDS'])
+    taaft.finetune_multiple_trials(cfg['NUM_TRIALS'])

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -134,12 +134,13 @@ class TAAFT:
         self.k = k
         self.clip_df = clip_df
 
-    def sample_folds(self, trial_folder):
+    def sample_folds(self, trial_folder, seed):
         '''
         Samples external data in self.clip_df into self.k folds. Preserves ratio of positive to negative classes in each fold.
         Folds are saved in a .txt file, where each fold is identified with an integer index, followed by each patient id
         in the fold on a new line.
         :param trial_folder: full path to folder in which to place patient folds. Corresponds to a particular trial.
+        :param seed: positive integer. Seed for shuffling patient ids.
         '''
         sliding_df = self.clip_df[self.clip_df['pleural_line_findings'] != 'absent_lung_sliding']
         no_sliding_df = self.clip_df[self.clip_df['pleural_line_findings'] == 'absent_lung_sliding']
@@ -152,8 +153,7 @@ class TAAFT:
         print("{} unique no-sliding patient ids found.\n".format(len(no_sliding_ids)))
 
         # Shuffle the patient ids.
-        seed_num = int(trial_folder[-1])
-        np.random.seed(cfg['FOLD_SAMPLE']['SEED'][seed_num - 1])
+        np.random.seed(seed)
         np.random.shuffle(sliding_ids)
         np.random.shuffle(no_sliding_ids)
 
@@ -518,7 +518,7 @@ class TAAFT:
                 os.makedirs(cur_trial_dir)
             else:
                 refresh_folder(cur_trial_dir)
-            self.sample_folds(cur_trial_dir)
+            self.sample_folds(cur_trial_dir, cfg['FOLD_SAMPLE']['SEED'][trial])
             self.finetune_single_trial(cur_trial_dir, lazy=cfg['FINETUNE']['LAZY'])
 
 

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -530,5 +530,5 @@ if __name__ == '__main__':
     external_df = get_external_clip_df()
 
     # Construct a TAAFT instance with the dataframe.
-    taaft = TAAFT(external_df, 5)
+    taaft = TAAFT(external_df, cfg['GENERALIZE']['FOLD_SAMPLE']['NUM_FOLDS'])
     taaft.finetune_multiple_trials(cfg['GENERALIZE']['NUM_TRIALS'])

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -51,6 +51,8 @@ def write_folds_to_txt(folds, file_path):
     Saves patient id folds to .txt file in the following structure:
     -> An integer, n, which indicates the length of the current fold
     -> Followed by n lines, each containing one (unique) patient id
+    :param folds: list of lists of strings. Represents a list of folds.
+    :params file_path: path where folds should be stored.
     '''
     txt = open(file_path, "a")
     for i in range(len(folds)):
@@ -75,6 +77,8 @@ def check_performance(df):
     '''
     Returns true if all metrics stored in the supplied results DataFrame meet fine-tuning standards, or False otherwise.
     :param df: DataFrame storing model performance metrics to be evaluated against fine-tune performance thresholds.
+
+    :return: Bool, whether performance in metrics df are satisfactory or not.
     '''
     # Return false if values less than these thresholds
     lower_bounds = ['accuracy', 'auc', 'recall', 'precision', 'true_negatives', 'true_positives']
@@ -111,6 +115,7 @@ class TAAFT:
         Samples external data in self.clip_df into self.k folds. Preserves ratio of positive to negative classes in each fold.
         Folds are saved in a .txt file, where each fold is identified with an integer index, followed by each patient id
         in the fold on a new line.
+        :param trial_folder: name of folder in which to place patient folds. Corresponds to a particular trial.
         '''
         sliding_df = self.clip_df[self.clip_df['pleural_line_findings'] != 'absent_lung_sliding']
         no_sliding_df = self.clip_df[self.clip_df['pleural_line_findings'] == 'absent_lung_sliding']
@@ -218,6 +223,7 @@ class TAAFT:
         '''
         Performs a single fine-tuning trial. Fine-tunes a model on external clip data, repeatedly augmenting external
         data slices to a training set until all external data has been used for training.
+        :param trial_folder: specifies folder in which to place metrics for current trial.
         :param hparams: Specifies the set of hyperparameters for fine-tuning the model.
         '''
 

--- a/src/make_splits.py
+++ b/src/make_splits.py
@@ -5,7 +5,7 @@ import yaml
 import random
 from sklearn.model_selection import train_test_split
 
-cfg = yaml.full_load(open(os.path.join(os.getcwd(), '../config.yml'), 'r'))
+cfg = yaml.full_load(open(os.path.join(os.getcwd(), 'config.yml'), 'r'))
 
 
 def df_splits_two_stream(df, flow_df, train, val, test, random_state=cfg['TRAIN']['SPLITS']['RANDOM_SEED']):


### PR DESCRIPTION
Draft for the multiple-trial code, which is in a TAAFT class method called `finetune_multiple_trials`. The method takes in a single parameter that indicates the number of desired trials. A significant number of the code changes were made to the existing fold-sampling and single-trial code (to keep track of trials).