### PR TITLE
Fixed Absent vs Present Lung Sliding Clip Labels (Switched 0's and 1's)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -270,7 +270,7 @@ EXPLAINABILITY:
 EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa', 'alberta']  # List of centers involved in the multi-center study.
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
-  NUM_TRIALS: 3  # Specify the number of fine-tuning trials.
+  NUM_TRIALS: 1  # Specify the number of fine-tuning trials.
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
@@ -295,8 +295,8 @@ EXTERNAL_VAL:
         SENSITIVITY: 90.1
         SPECIFICITY: 79.3
       UPPER_BOUNDS:
-    VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 10
+    VAL_SPLIT: 0.2 # Specify the train-val data split for each fine-tune run.
+    EPOCHS: 25
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.

--- a/src/make_splits.py
+++ b/src/make_splits.py
@@ -149,11 +149,11 @@ else:
     sliding_df = df_splits_two_stream(sliding_df, flow_sliding_df, train_prop, val_prop, test_prop)
     no_sliding_df = df_splits_two_stream(no_sliding_df, flow_no_sliding_df, train_prop, val_prop, test_prop)
 
-# Add label to dataframes
-l1 = [1] * len(sliding_df)
-sliding_df['label'] = l1
-l0 = [0] * len(no_sliding_df)
-no_sliding_df['label'] = l0
+# Add label to dataframes. We consider absent lung sliding to be the "positive" class here, hence the label of 1.
+l0 = [0] * len(sliding_df)
+sliding_df['label'] = l0
+l1 = [1] * len(no_sliding_df)
+no_sliding_df['label'] = l1
 
 # Add file path to dataframes
 npz_dir = ''


### PR DESCRIPTION
Switched 0 and 1 labels for lung sliding clips: absent lung sliding is now indicated as a 1, while present lung sliding is 0.