### PR TITLE
Save and plot finetune results, configurable minimum external test set size.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -270,7 +270,7 @@ EXPLAINABILITY:
 EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa', 'alberta']  # List of centers involved in the multi-center study.
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
-  NUM_TRIALS: 5  # Specify the number of fine-tuning trials.
+  NUM_TRIALS: 1  # Specify the number of fine-tuning trials.
   MIN_TEST_SIZE: 0.5  # Specify the minimum proportion of external data to set aside for testing purposes.
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
@@ -293,12 +293,12 @@ EXTERNAL_VAL:
     OVERWRITE_MODEL_DIR: True  # Set True if you want to clear existing contents in the model folder.
     METRIC_THRESHOLDS:  # Thresholds for assessing the performance of a fine-tuned model.
       LOWER_BOUNDS:
-        SENSITIVITY: 90.1
-        SPECIFICITY: 79.3
+        SENSITIVITY: 79.3
+        SPECIFICITY: 90.1
       UPPER_BOUNDS:
     MIN_DELTA: 0.0001
     VAL_SPLIT: 0.2 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 1
+    EPOCHS: 100
     PRED_PROBS:
       SAVE_PRED_PROBABILITIES: True # Set to True to save prediction labels for each clip when evaluating fine-tuned models.
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.

--- a/config.yml
+++ b/config.yml
@@ -56,7 +56,7 @@ TRAIN:
   M_MODE_SLICE_SAMPLE: 15 # for 'brightest_vertical_sum_sampled', number of slices to randomly sample (top k brightest sums)
   MIXED_PRECISION: False
   OUTPUT_BIAS: False  # A class imbalance technique - whether or not to bias the model (output head) prior to training.
-  PATIENCE: 12  # The number of consecutive epochs with val_loss not improving, after which the model halts training.
+  PATIENCE: 6  # The number of consecutive epochs with val_loss not improving, after which the model halts training.
   MODEL_DEF: 'efficientnet'  # Check models.py for the current list of possible values (which is also where you would create a custom one).
   SAVE_BEST_ONLY: True  # Whether or not to only save the 'best' model, according to validation loss.
 
@@ -282,7 +282,7 @@ EXTERNAL_VAL:
     CSVS_SPLIT: '\generalizability\csvs_split'  # Path to train-test-val splits for external data.
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments'
-    TRIALS: '\generalizability\results\trials'
+    TRIALS: '\generalizability\results\experiments\trials'
     PLOTS: '\generalizability\results\experiments\plots'
   FOLD_SAMPLE:
     SEED: 42069  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
@@ -298,7 +298,7 @@ EXTERNAL_VAL:
         SPECIFICITY: 79.3
       UPPER_BOUNDS:
     VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 50
+    EPOCHS: 100
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.

--- a/config.yml
+++ b/config.yml
@@ -283,8 +283,6 @@ EXTERNAL_VAL:
     CSVS_SPLIT: '\generalizability\csvs_split'  # Path to train-test-val splits for external data.
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments'
-    TRIALS: '\generalizability\results\experiments\trials'
-    PLOTS: '\generalizability\results\experiments\plots'
   FOLD_SAMPLE:
     SEED: 42069  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     # There is one seed for each trial; insert or remove (or change) seeds as necessary/desired.

--- a/config.yml
+++ b/config.yml
@@ -71,7 +71,7 @@ TRAIN:
   # Parameters for augmentation and model-training specifics.
   PARAMS:
     EPOCHS: 40  # Maximum number of epochs to train the model for.
-    BATCH_SIZE: 40  # Integer to set the batch size. If you're running into memory errors, you'll have to lower this. Set this to 1 for GRADCAM.
+    BATCH_SIZE: 25  # Integer to set the batch size. If you're running into memory errors, you'll have to lower this. Set this to 1 for GRADCAM.
     SHUFFLE: True  # Boolean, whether to shuffle the training set or not.
     INCREASE: False  # Boolean, whether to oversample the minority class (assumed to be the negative class) or not.
     AUGMENTATION_CHANCE: 0.8  # Probability to augment an incoming batch.

--- a/config.yml
+++ b/config.yml
@@ -270,7 +270,7 @@ EXPLAINABILITY:
 EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa', 'alberta']  # List of centers involved in the multi-center study.
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
-  NUM_TRIALS: 3  # Specify the number of fine-tuning trials.
+  NUM_TRIALS: 1  # Specify the number of fine-tuning trials.
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
@@ -295,8 +295,8 @@ EXTERNAL_VAL:
         SENSITIVITY: 90.1
         SPECIFICITY: 79.3
       UPPER_BOUNDS:
-    VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 10
+    VAL_SPLIT: 0.2 # Specify the train-val data split for each fine-tune run.
+    EPOCHS: 25
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.

--- a/config.yml
+++ b/config.yml
@@ -33,8 +33,8 @@ PREPROCESS:
     MASKED_VIDEOS: '\generalizability\masked_videos\alberta'  # Path to the videos that result from running the masking tool on UNMASKED_VIDEOS.
     SMOOTHED_VIDEOS: '\results\data\smoothed_videos\'  # Path to the videos that result from applying a median filter to MASKED_VIDEOS (optional).
     FLOW_VIDEOS: 'flow_videos\'   # Path to the optical flow video frames (optional).
-    CSVS_OUTPUT: '\generalizability\csvs\alberta'  # Path to any CSVs that are generated / taken from the database.
-    NPZ: '\generalizability\npzs\alberta'  # Path to the mini-clip videos.
+    CSVS_OUTPUT: 'generalizability\csvs\alberta'  # Path to any CSVs that are generated / taken from the database.
+    NPZ: 'C:\Users\hsmle\Documents\Deep_Breathe\lung-sliding-classifier\generalizability\npzs\alberta'  # Path to the mini-clip videos.
     FLOW_NPZ: 'flow_npzs\'  # Path to the .npzs containing optical flow mini-clips.
     MASKING_TOOL: '\results\data\auto_masking_deeper.h5'  # Path to the masking tool. Currently only works with the older version!!!
 
@@ -270,7 +270,8 @@ EXPLAINABILITY:
 EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa', 'alberta']  # List of centers involved in the multi-center study.
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
-  NUM_TRIALS: 1  # Specify the number of fine-tuning trials.
+  NUM_TRIALS: 5  # Specify the number of fine-tuning trials.
+  MIN_TEST_SIZE: 0.5  # Specify the minimum proportion of external data to set aside for testing purposes.
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
@@ -282,6 +283,7 @@ EXTERNAL_VAL:
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments'
     TRIALS: '\generalizability\results\trials'
+    PLOTS: '\generalizability\results\experiments\plots'
   FOLD_SAMPLE:
     SEED: 42069  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     # There is one seed for each trial; insert or remove (or change) seeds as necessary/desired.
@@ -295,8 +297,9 @@ EXTERNAL_VAL:
         SENSITIVITY: 90.1
         SPECIFICITY: 79.3
       UPPER_BOUNDS:
-    VAL_SPLIT: 0.2 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 25
+    VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
+    EPOCHS: 50
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.
+  PLOT_METRICS: ['loss', 'sensitivity', 'specificity']  # Specify metrics for which to generate plots (for each trial and trial-wise average).

--- a/config.yml
+++ b/config.yml
@@ -97,7 +97,7 @@ TRAIN:
       LR_DECAY_VAL: 0.05642  # Learning rate decay
       LR_DECAY_EPOCH: 15 # Epoch to start lr decay
       DROPOUT: 0.2151 # Dropout probability
-      BLOCKS_FROZEN: 30 # Number of blocks to freeze - MUST be 0 or positive
+      BLOCKS_FROZEN: 161 # Number of blocks to freeze - MUST be 0 or positive
       L2_REG: 0.008629 # L2 regularization penalty
       WEIGHT_INITIALIZER: 'he_normal'  # Method to initialize weights for convolutional and FC layers - see https://www.tensorflow.org/api_docs/python/tf/keras/initializers
       ALPHA: 0.105 # focal loss parameter
@@ -275,6 +275,7 @@ EXTERNAL_VAL:
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
+    NPZS: '\generalizability\npzs'
     MMODES: '\generalizability\mmodes'  # Path to external data M-mode images.
     CSV_OUT: '\generalizability\csvs'  # Path to external data csvs.
     MODEL_OUT: '\generalizability\results\models'  # Path to fine-tuned models.
@@ -300,6 +301,8 @@ EXTERNAL_VAL:
     MIN_DELTA: 0.0001
     VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
     EPOCHS: 100
+    PRED_PROBS:
+      SAVE_PRED_PROBABILITIES: True # Set to True to save prediction labels for each clip when evaluating fine-tuned models.
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.

--- a/config.yml
+++ b/config.yml
@@ -270,7 +270,7 @@ EXPLAINABILITY:
 EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa', 'alberta']  # List of centers involved in the multi-center study.
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
-  NUM_TRIALS: 5  # Specify the number of fine-tuning trials.
+  NUM_TRIALS: 1  # Specify the number of fine-tuning trials.
   MIN_TEST_SIZE: 0.5  # Specify the minimum proportion of external data to set aside for testing purposes.
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.

--- a/config.yml
+++ b/config.yml
@@ -34,7 +34,7 @@ PREPROCESS:
     SMOOTHED_VIDEOS: '\results\data\smoothed_videos\'  # Path to the videos that result from applying a median filter to MASKED_VIDEOS (optional).
     FLOW_VIDEOS: 'flow_videos\'   # Path to the optical flow video frames (optional).
     CSVS_OUTPUT: 'generalizability\csvs\alberta'  # Path to any CSVs that are generated / taken from the database.
-    NPZ: 'C:\Users\hsmle\Documents\Deep_Breathe\lung-sliding-classifier\generalizability\npzs\alberta'  # Path to the mini-clip videos.
+    NPZ: 'generalizability\npzs\alberta'  # Path to the mini-clip videos.
     FLOW_NPZ: 'flow_npzs\'  # Path to the .npzs containing optical flow mini-clips.
     MASKING_TOOL: '\results\data\auto_masking_deeper.h5'  # Path to the masking tool. Currently only works with the older version!!!
 
@@ -297,8 +297,9 @@ EXTERNAL_VAL:
         SENSITIVITY: 90.1
         SPECIFICITY: 79.3
       UPPER_BOUNDS:
+    MIN_DELTA: 0.0001
     VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 100
+    EPOCHS: 1
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.

--- a/config.yml
+++ b/config.yml
@@ -297,7 +297,7 @@ EXTERNAL_VAL:
         SPECIFICITY: 79.3
       UPPER_BOUNDS:
     MIN_DELTA: 0.0001
-    VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
+    VAL_SPLIT: 0.2 # Specify the train-val data split for each fine-tune run.
     EPOCHS: 100
     PRED_PROBS:
       SAVE_PRED_PROBABILITIES: True # Set to True to save prediction labels for each clip when evaluating fine-tuned models.

--- a/config.yml
+++ b/config.yml
@@ -71,7 +71,7 @@ TRAIN:
   # Parameters for augmentation and model-training specifics.
   PARAMS:
     EPOCHS: 40  # Maximum number of epochs to train the model for.
-    BATCH_SIZE: 25  # Integer to set the batch size. If you're running into memory errors, you'll have to lower this. Set this to 1 for GRADCAM.
+    BATCH_SIZE: 10  # Integer to set the batch size. If you're running into memory errors, you'll have to lower this. Set this to 1 for GRADCAM.
     SHUFFLE: True  # Boolean, whether to shuffle the training set or not.
     INCREASE: False  # Boolean, whether to oversample the minority class (assumed to be the negative class) or not.
     AUGMENTATION_CHANCE: 0.8  # Probability to augment an incoming batch.
@@ -299,7 +299,7 @@ EXTERNAL_VAL:
       UPPER_BOUNDS:
     MIN_DELTA: 0.0001
     VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 1
+    EPOCHS: 100
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.

--- a/config.yml
+++ b/config.yml
@@ -29,13 +29,13 @@ PREPROCESS:
   # The paths to save files. After running the preprocess pipeline, the npzs and csvs are usually all that are needed to train.
   # You shouldn't *have* to edit these, as they are stored as relative and not absolute paths.
   PATHS:
-    UNMASKED_VIDEOS: '\generalizability\raw_videos/alberta'  # Path to the videos that are downloaded from the dataset and stored without transformation.
+    UNMASKED_VIDEOS: '\generalizability\raw_videos\alberta'  # Path to the videos that are downloaded from the dataset and stored without transformation.
     MASKED_VIDEOS: '\generalizability\masked_videos\alberta'  # Path to the videos that result from running the masking tool on UNMASKED_VIDEOS.
-    SMOOTHED_VIDEOS: '\results/data\smoothed_videos/'  # Path to the videos that result from applying a median filter to MASKED_VIDEOS (optional).
-    FLOW_VIDEOS: 'flow_videos/'   # Path to the optical flow video frames (optional).
+    SMOOTHED_VIDEOS: '\results\data\smoothed_videos\'  # Path to the videos that result from applying a median filter to MASKED_VIDEOS (optional).
+    FLOW_VIDEOS: 'flow_videos\'   # Path to the optical flow video frames (optional).
     CSVS_OUTPUT: '\generalizability\csvs\alberta'  # Path to any CSVs that are generated / taken from the database.
     NPZ: '\generalizability\npzs\alberta'  # Path to the mini-clip videos.
-    FLOW_NPZ: 'flow_npzs/'  # Path to the .npzs containing optical flow mini-clips.
+    FLOW_NPZ: 'flow_npzs\'  # Path to the .npzs containing optical flow mini-clips.
     MASKING_TOOL: '\results\data\auto_masking_deeper.h5'  # Path to the masking tool. Currently only works with the older version!!!
 
     # EXTRA refers to the first infusion of negative additions, which at the time of writing is kept separate
@@ -274,14 +274,14 @@ EXTERNAL_VAL:
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
-    MMODES: '/generalizability/mmodes'  # Path to external data M-mode images.
-    CSV_OUT: '/generalizability/csvs'  # Path to external data csvs.
-    MODEL_OUT: '/generalizability/results/models'  # Path to fine-tuned models.
-    FOLDS: '/generalizability/folds'  # Path to external data patient-wise fold .txt files.
-    CSVS_SPLIT: '/generalizability/csvs_split'  # Path to train-test-val splits for external data.
-    PREDICTIONS_OUT: '/generalizability/predictions'  # Path to predictions from fine-tuning experiments.
-    EXPERIMENTS: '/generalizability/results/experiments'
-    TRIALS: '/generalizability/results/trials'
+    MMODES: '\generalizability\mmodes'  # Path to external data M-mode images.
+    CSV_OUT: '\generalizability\csvs'  # Path to external data csvs.
+    MODEL_OUT: '\generalizability\results\models'  # Path to fine-tuned models.
+    FOLDS: '\generalizability\folds'  # Path to external data patient-wise fold .txt files.
+    CSVS_SPLIT: '\generalizability\csvs_split'  # Path to train-test-val splits for external data.
+    PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
+    EXPERIMENTS: '\generalizability\results\experiments'
+    TRIALS: '\generalizability\results\trials'
   FOLD_SAMPLE:
     SEED: 42069  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     # There is one seed for each trial; insert or remove (or change) seeds as necessary/desired.

--- a/config.yml
+++ b/config.yml
@@ -71,7 +71,7 @@ TRAIN:
   # Parameters for augmentation and model-training specifics.
   PARAMS:
     EPOCHS: 40  # Maximum number of epochs to train the model for.
-    BATCH_SIZE: 10  # Integer to set the batch size. If you're running into memory errors, you'll have to lower this. Set this to 1 for GRADCAM.
+    BATCH_SIZE: 40  # Integer to set the batch size. If you're running into memory errors, you'll have to lower this. Set this to 1 for GRADCAM.
     SHUFFLE: True  # Boolean, whether to shuffle the training set or not.
     INCREASE: False  # Boolean, whether to oversample the minority class (assumed to be the negative class) or not.
     AUGMENTATION_CHANCE: 0.8  # Probability to augment an incoming batch.
@@ -97,7 +97,7 @@ TRAIN:
       LR_DECAY_VAL: 0.05642  # Learning rate decay
       LR_DECAY_EPOCH: 15 # Epoch to start lr decay
       DROPOUT: 0.2151 # Dropout probability
-      BLOCKS_FROZEN: 161 # Number of blocks to freeze - MUST be 0 or positive
+      BLOCKS_FROZEN: 220 # Number of blocks to freeze - MUST be 0 or positive
       L2_REG: 0.008629 # L2 regularization penalty
       WEIGHT_INITIALIZER: 'he_normal'  # Method to initialize weights for convolutional and FC layers - see https://www.tensorflow.org/api_docs/python/tf/keras/initializers
       ALPHA: 0.105 # focal loss parameter
@@ -270,7 +270,7 @@ EXPLAINABILITY:
 EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa', 'alberta']  # List of centers involved in the multi-center study.
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
-  NUM_TRIALS: 1  # Specify the number of fine-tuning trials.
+  NUM_TRIALS: 5  # Specify the number of fine-tuning trials.
   MIN_TEST_SIZE: 0.5  # Specify the minimum proportion of external data to set aside for testing purposes.
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
@@ -284,7 +284,7 @@ EXTERNAL_VAL:
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments'
   FOLD_SAMPLE:
-    SEED: 42069  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
+    SEED: 123  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     # There is one seed for each trial; insert or remove (or change) seeds as necessary/desired.
     OVERWRITE_FOLDER: True  # Set this to True if you want to overwrite existing fold .txt files.
     NUM_FOLDS: 5  # Number of desired external patient slices for augmenting training data during fine-tuning.
@@ -298,7 +298,7 @@ EXTERNAL_VAL:
       UPPER_BOUNDS:
     MIN_DELTA: 0.0001
     VAL_SPLIT: 0.2 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 100
+    EPOCHS: 1
     PRED_PROBS:
       SAVE_PRED_PROBABILITIES: True # Set to True to save prediction labels for each clip when evaluating fine-tuned models.
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.

--- a/src/data/results/finetune_results_utils.py
+++ b/src/data/results/finetune_results_utils.py
@@ -125,18 +125,3 @@ def plot_finetune_results(results_csv):
 #
 # plot_finetune_results(res_df)
 
-if __name__ == '__main__':
-    import keras
-    experiments_dir = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
-    experiment_path = os.path.join(experiments_dir, os.listdir(experiments_dir)[-3])
-    exp_path_2 = os.path.join(experiments_dir, os.listdir(experiments_dir)[-8])
-    model = keras.models.load_model(os.path.join(experiment_path, 'trial_1', 'models', 'model_0.2_percent_train'), compile=False)
-    model_2 = keras.models.load_model(os.path.join(exp_path_2, 'trial_1', 'models', 'model_0.2_percent_train'), compile=False)
-    # count = 0
-    # for layer in model.layers:
-    #     print(layer.get_config())
-    #     if not layer.get_config()['trainable']:
-    #         count += 1
-    # print('Frozen layers:', count)
-    print(model.summary())
-    print(model_2.summary())

--- a/src/data/results/finetune_results_utils.py
+++ b/src/data/results/finetune_results_utils.py
@@ -2,94 +2,125 @@ import pandas as pd
 import os
 import yaml
 import matplotlib.pyplot as plt
-from src.data.sql_utils import add_date_to_filename
-from src.data.utils import refresh_folder
+import glob
+import numpy as np
+from shutil import rmtree
 
 cfg = yaml.full_load(open(os.path.join(os.getcwd(), "config.yml"), 'r'))['EXTERNAL_VAL']
 
 
-def finetune_results_to_csv(experiment_path=os.getcwd() + cfg['PATHS']['EXPERIMENTS']):
+def finetune_results_to_csv(experiment_path):
     '''
     Saves finetune results for each trial (and for each fold in that trial) as a csv file.
-    :param experiment_path: Full path to fine-tuning experiment files.
-    :return Str: Full path to the .csv file containing finetuning results across all trials.
+    :param experiment_path: Absolute path to fine-tuning experiment files.
+    :return Str: Absolute path to the .csv file containing finetuning results across all trials.
     '''
-    trial_results = []
-    for result_csv in os.listdir(experiment_path):
-        # The experiment folder also contains a subdirectory for plots. Skip over this to get to the actual result csvs.
-        if os.path.isdir(os.path.join(experiment_path, result_csv)):
-            continue
-        trial_results.append(pd.read_csv(os.path.join(experiment_path, result_csv)))
+    # trial_results is going to be the combined results .csv file.
+    trial_results = pd.DataFrame([])
+    trial_folders = glob.glob(os.path.join(experiment_path, 'trial_[0-9]*'))
 
-    trial_results = pd.concat(trial_results, ignore_index=True)
-    num_trials = cfg['NUM_TRIALS']
-    num_data_slices = len(os.listdir(experiment_path)) // num_trials
-    ext_data_props = [(n + 1) / num_trials for n in range(num_data_slices)] * num_trials
-    ext_data_props = pd.DataFrame(ext_data_props, columns=['ext_train_prop'])
-    trial_index = []
-    for t in range(num_trials):
-        trial_index.extend([t + 1] * num_data_slices)
-    trial_index = pd.DataFrame(trial_index, columns=['trial'])
-    trial_results = pd.concat([trial_index, ext_data_props, trial_results], axis=1)
-    print(trial_results)
-    # Adding '_df.csv' to the end of the resulting file name gets rid of permission error. Might want to investigate
-    # this further.
-    final_path = os.path.join(os.getcwd() + cfg['PATHS']['CSV_OUT'], add_date_to_filename('experiment_results') + '_df.csv')
+    # trial_numbers specifies which trial each result row is for in the .csv file.
+    trial_numbers = []
+    cur_trial_num = 1
+
+    # Combine results across all trials.
+    for trial in trial_folders:
+        metric_results_csv_path = glob.glob(os.path.join(trial, '*.csv'))[0]
+        metric_results_csv = pd.read_csv(metric_results_csv_path, index_col=0)
+        trial_numbers.extend([cur_trial_num] * len(metric_results_csv))
+        trial_results = pd.concat([trial_results, metric_results_csv])
+        cur_trial_num += 1
+
+    # Add trial_numbers as a column to the combined results df. Save as .csv file.
+    trial_numbers = pd.DataFrame(trial_numbers, columns=['trial']).reset_index(drop=True)
+    trial_results = trial_results.reset_index(drop=True)
+    trial_results = pd.concat([trial_numbers, trial_results], axis=1)
+    experiment_name = experiment_path.split('\\')[-1]
+    final_path = os.path.join(experiment_path, experiment_name + '_results.csv')
     trial_results.to_csv(final_path)
+
     return final_path
 
 
 def plot_finetune_results(results_csv):
     '''
-    Plots finetuning results for metrics specified in the config file (currently loss/sensitivity/specificity). Plots
-    results by individual trial along with trial-wise averages for each metric.
-    :param results_csv: Full path to .csv file containing fine-tuning results
+    Plots fine-tuning results for metrics specified in the config file (currently loss/sensitivity/specificity).
+    Generates a plot for each metric in results_csv by trial, along with trial-wise averages for each metric.
+    :param results_csv: Absolute path to .csv file containing fine-tuning results.
     '''
     results_df = pd.read_csv(results_csv)
-    num_trials = cfg['NUM_TRIALS']
-    num_data_slices = len(results_df) // num_trials
-    # Set up the x-axis for plotting.
-    x = list(results_df['ext_train_prop'])[:num_data_slices]
-    plot_metrics = cfg['PLOT_METRICS']
-    path_to_plots = os.getcwd() + cfg['PATHS']['PLOTS']
-    if cfg['REFRESH_FOLDERS']:
-        refresh_folder(path_to_plots)
-    # Extract metric values from result df. Generate plots and save them.
-    plt_ind = 0
-    for metric in plot_metrics:
-        metric_values = results_df[metric].values
-        y = []
-        for i in range(0, len(metric_values), num_data_slices):
-            y.append(metric_values[i:i + num_data_slices])
-        plt.figure(plt_ind)
-        for trial_y in y:
-            plt.plot(x, trial_y)
-        # Compute trial-wise average metric value
-        trial_avgs = []
-        for i in range(num_data_slices):
-            total = 0
-            for j in range(num_trials):
-                total += metric_values[i + j * num_data_slices]
-            avg = total / num_trials
-            trial_avgs.append(avg)
-        plt.plot(x, trial_avgs, linestyle='dashed')
-        plt.xticks(x)
-        plt.xlabel('External Training Data Proportion')
-        # Sensitivity and specificity metric values need to be flipped to follow convention with original lung sliding
-        # manuscript.
-        if metric == 'sensitivity':
-            metric = 'specificity'
-        elif metric == 'specificity':
-            metric = 'sensitivity'
-        # Capitalize the name of the metric
-        y_axis_label = metric[0].upper() + metric[1:]
-        plt.ylabel(y_axis_label)
-        plt.title(y_axis_label + ' vs Proportion of External Data as Train Set')
-        legend_strs = []
-        for i in range(num_trials):
-            legend_strs.append('Trial ' + str(i + 1))
-        legend_strs.append('Average ' + y_axis_label + ' (Trial-Wise)')
-        plt.legend(legend_strs)
-        plt.savefig(os.path.join(path_to_plots, add_date_to_filename(metric) + '.jpg'))
-        plt_ind += 1
 
+    # The absolute path to the corresponding experiment is the parent directory for the results .csv file.
+    experiment_path = '\\'.join(results_csv.split('\\')[:-1])
+
+    # Make a folder to store the plots.
+    plot_dir = os.path.join(experiment_path, 'plots')
+
+    # If there are already plots in the experiment folder, overwrite with new plots.
+    if os.path.exists(plot_dir):
+        rmtree(plot_dir)
+
+    os.makedirs(plot_dir)
+
+    # Get list of external data proportions used for training in the experiment.
+    first_trial_results = results_df[results_df['trial'] == 1]
+    ext_data_props = first_trial_results[first_trial_results['variable_sized_test_set'] == 1]['ext_data_prop'].values
+
+    metrics = cfg['PLOT_METRICS']
+    num_trials = cfg['NUM_TRIALS']
+    plot_ind = 0
+    legend_labels = []
+
+    for metric in metrics:
+        # New figure.
+        plt.figure(plot_ind)
+        plt.xlabel('Proportion of External Data Used for Train')
+        metric_name = metric[0].upper() + metric[1:]
+        plt.ylabel(metric_name)
+        plt.title(metric_name + ' vs External Train Proportion')
+
+        for test_set_type in [1, 0]:
+            style = 'solid'
+            if test_set_type == 0:
+                style = 'dashed'
+            results_for_test_set_type = results_df[results_df['variable_sized_test_set'] == test_set_type]
+            test_set_size_label = '({} Test Set Size)'.format('Variable' if test_set_type == 1 else 'Fixed')
+
+            # Plot results for each trial.
+            for t in range(num_trials):
+                results_to_plot = results_for_test_set_type[results_for_test_set_type['trial'] == t + 1]
+
+                # Plot results for each of variable and fixed test set sizes.
+                trial_metric_vals = results_to_plot[metric].values
+                plt.plot(ext_data_props, trial_metric_vals, linestyle=style)
+
+                legend_labels.append('Trial {} {}'.format(t + 1, test_set_size_label))
+
+            # Plot average metric value across trials.
+            trial_avgs = []
+            for prop in ext_data_props:
+                avg_for_prop = np.mean(results_for_test_set_type[results_for_test_set_type['variable_sized_test_set'] ==
+                                                                 test_set_type][metric])
+                trial_avgs.append(avg_for_prop)
+
+            # Trial-wise averages are denoted with bold lines.
+            plt.plot(ext_data_props, trial_avgs, linestyle=style, linewidth=3)
+
+            legend_labels.append('Trial-Wise Average {}'.format(test_set_size_label))
+
+        # Add a legend
+        plt.legend(legend_labels, bbox_to_anchor=(1, 2))
+
+        experiment_name = experiment_path.split('\\')[-1]
+        plt.savefig(os.path.join(plot_dir, experiment_name + '_' + metric + '.png'))
+
+        # Update plot figure counter.
+        plot_ind += 1
+        legend_labels = []
+
+
+experiment_path = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
+experiment_path = os.path.join(experiment_path, os.listdir(experiment_path)[-1])
+res_df = finetune_results_to_csv(experiment_path)
+
+plot_finetune_results(res_df)

--- a/src/data/results/finetune_results_utils.py
+++ b/src/data/results/finetune_results_utils.py
@@ -124,3 +124,19 @@ def plot_finetune_results(results_csv):
 # res_df = finetune_results_to_csv(experiment_path)
 #
 # plot_finetune_results(res_df)
+
+if __name__ == '__main__':
+    import keras
+    experiments_dir = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
+    experiment_path = os.path.join(experiments_dir, os.listdir(experiments_dir)[-3])
+    exp_path_2 = os.path.join(experiments_dir, os.listdir(experiments_dir)[-8])
+    model = keras.models.load_model(os.path.join(experiment_path, 'trial_1', 'models', 'model_0.2_percent_train'), compile=False)
+    model_2 = keras.models.load_model(os.path.join(exp_path_2, 'trial_1', 'models', 'model_0.2_percent_train'), compile=False)
+    # count = 0
+    # for layer in model.layers:
+    #     print(layer.get_config())
+    #     if not layer.get_config()['trainable']:
+    #         count += 1
+    # print('Frozen layers:', count)
+    print(model.summary())
+    print(model_2.summary())

--- a/src/data/results/finetune_results_utils.py
+++ b/src/data/results/finetune_results_utils.py
@@ -25,7 +25,7 @@ def finetune_results_to_csv(experiment_path):
 
     # Combine results across all trials.
     for trial in trial_folders:
-        metric_results_csv_path = glob.glob(os.path.join(trial, '*.csv'))[0]
+        metric_results_csv_path = glob.glob(os.path.join(trial, '*.csv'))[1]
         metric_results_csv = pd.read_csv(metric_results_csv_path, index_col=0)
         trial_numbers.extend([cur_trial_num] * len(metric_results_csv))
         trial_results = pd.concat([trial_results, metric_results_csv])
@@ -118,10 +118,16 @@ def plot_finetune_results(results_csv):
         plot_ind += 1
         legend_labels = []
 
-
+#
 # experiment_path = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
 # experiment_path = os.path.join(experiment_path, os.listdir(experiment_path)[-1])
 # res_df = finetune_results_to_csv(experiment_path)
 #
 # plot_finetune_results(res_df)
 
+# if __name__ == '__main__':
+#     exp_dir = os.path.join(os.getcwd() + cfg['PATHS']['EXPERIMENTS'])
+#     exp_path = glob.glob(os.path.join(exp_dir, 'experiment_1660921548.0\\trial_1\\upsample_miniclips.csv'))[0]
+#     upsample_csv = pd.read_csv(exp_path)
+#     print(len(upsample_csv))
+#     print(upsample_csv.loc[upsample_csv.duplicated(subset=['miniclip_id'])])

--- a/src/data/results/finetune_results_utils.py
+++ b/src/data/results/finetune_results_utils.py
@@ -119,8 +119,8 @@ def plot_finetune_results(results_csv):
         legend_labels = []
 
 
-experiment_path = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
-experiment_path = os.path.join(experiment_path, os.listdir(experiment_path)[-1])
-res_df = finetune_results_to_csv(experiment_path)
-
-plot_finetune_results(res_df)
+# experiment_path = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
+# experiment_path = os.path.join(experiment_path, os.listdir(experiment_path)[-1])
+# res_df = finetune_results_to_csv(experiment_path)
+#
+# plot_finetune_results(res_df)

--- a/src/data/results/finetune_results_utils.py
+++ b/src/data/results/finetune_results_utils.py
@@ -1,0 +1,95 @@
+import pandas as pd
+import os
+import yaml
+import matplotlib.pyplot as plt
+from src.data.sql_utils import add_date_to_filename
+from src.data.utils import refresh_folder
+
+cfg = yaml.full_load(open(os.path.join(os.getcwd(), "config.yml"), 'r'))['EXTERNAL_VAL']
+
+
+def finetune_results_to_csv(experiment_path=os.getcwd() + cfg['PATHS']['EXPERIMENTS']):
+    '''
+    Saves finetune results for each trial (and for each fold in that trial) as a csv file.
+    :param experiment_path: Full path to fine-tuning experiment files.
+    :return Str: Full path to the .csv file containing finetuning results across all trials.
+    '''
+    trial_results = []
+    for result_csv in os.listdir(experiment_path):
+        # The experiment folder also contains a subdirectory for plots. Skip over this to get to the actual result csvs.
+        if os.path.isdir(os.path.join(experiment_path, result_csv)):
+            continue
+        trial_results.append(pd.read_csv(os.path.join(experiment_path, result_csv)))
+
+    trial_results = pd.concat(trial_results, ignore_index=True)
+    num_trials = cfg['NUM_TRIALS']
+    num_data_slices = len(os.listdir(experiment_path)) // num_trials
+    ext_data_props = [(n + 1) / num_trials for n in range(num_data_slices)] * num_trials
+    ext_data_props = pd.DataFrame(ext_data_props, columns=['ext_train_prop'])
+    trial_index = []
+    for t in range(num_trials):
+        trial_index.extend([t + 1] * num_data_slices)
+    trial_index = pd.DataFrame(trial_index, columns=['trial'])
+    trial_results = pd.concat([trial_index, ext_data_props, trial_results], axis=1)
+    print(trial_results)
+    # Adding '_df.csv' to the end of the resulting file name gets rid of permission error. Might want to investigate
+    # this further.
+    final_path = os.path.join(os.getcwd() + cfg['PATHS']['CSV_OUT'], add_date_to_filename('experiment_results') + '_df.csv')
+    trial_results.to_csv(final_path)
+    return final_path
+
+
+def plot_finetune_results(results_csv):
+    '''
+    Plots finetuning results for metrics specified in the config file (currently loss/sensitivity/specificity). Plots
+    results by individual trial along with trial-wise averages for each metric.
+    :param results_csv: Full path to .csv file containing fine-tuning results
+    '''
+    results_df = pd.read_csv(results_csv)
+    num_trials = cfg['NUM_TRIALS']
+    num_data_slices = len(results_df) // num_trials
+    # Set up the x-axis for plotting.
+    x = list(results_df['ext_train_prop'])[:num_data_slices]
+    plot_metrics = cfg['PLOT_METRICS']
+    path_to_plots = os.getcwd() + cfg['PATHS']['PLOTS']
+    if cfg['REFRESH_FOLDERS']:
+        refresh_folder(path_to_plots)
+    # Extract metric values from result df. Generate plots and save them.
+    plt_ind = 0
+    for metric in plot_metrics:
+        metric_values = results_df[metric].values
+        y = []
+        for i in range(0, len(metric_values), num_data_slices):
+            y.append(metric_values[i:i + num_data_slices])
+        plt.figure(plt_ind)
+        for trial_y in y:
+            plt.plot(x, trial_y)
+        # Compute trial-wise average metric value
+        trial_avgs = []
+        for i in range(num_data_slices):
+            total = 0
+            for j in range(num_trials):
+                total += metric_values[i + j * num_data_slices]
+            avg = total / num_trials
+            trial_avgs.append(avg)
+        plt.plot(x, trial_avgs, linestyle='dashed')
+        plt.xticks(x)
+        plt.xlabel('External Training Data Proportion')
+        # Sensitivity and specificity metric values need to be flipped to follow convention with original lung sliding
+        # manuscript.
+        if metric == 'sensitivity':
+            metric = 'specificity'
+        elif metric == 'specificity':
+            metric = 'sensitivity'
+        # Capitalize the name of the metric
+        y_axis_label = metric[0].upper() + metric[1:]
+        plt.ylabel(y_axis_label)
+        plt.title(y_axis_label + ' vs Proportion of External Data as Train Set')
+        legend_strs = []
+        for i in range(num_trials):
+            legend_strs.append('Trial ' + str(i + 1))
+        legend_strs.append('Average ' + y_axis_label + ' (Trial-Wise)')
+        plt.legend(legend_strs)
+        plt.savefig(os.path.join(path_to_plots, add_date_to_filename(metric) + '.jpg'))
+        plt_ind += 1
+

--- a/src/data/save_m_modes.py
+++ b/src/data/save_m_modes.py
@@ -2,18 +2,21 @@ import os
 import numpy as np
 import yaml
 import cv2
+import glob
+import random
+import shutil
 from utils import refresh_folder
 
 cfg = yaml.full_load(open(os.path.join(os.getcwd(), "..\\..\\config.yml"), 'r'))['PREPROCESS']
 cfg_full = yaml.full_load(open(os.path.join(os.getcwd(), "..\\..\\config.yml"), 'r'))
 
-mmode_dir = cfg_full['GENERALIZE']['PATHS']['MMODES']
+mmode_dir = cfg_full['EXTERNAL_VAL']['PATHS']['MMODES']
 npz_dir = cfg['PATHS']['NPZ']
 
 if not os.path.exists(mmode_dir):
     os.makedirs(mmode_dir)
 
-if cfg_full['GENERALIZE']['REFRESH_FOLDERS']:
+if cfg_full['EXTERNAL_VAL']['REFRESH_FOLDERS']:
     refresh_folder(mmode_dir)
 
 
@@ -45,19 +48,81 @@ def get_clip_length(video_path):
     return duration
 
 
-if __name__ == '__main__':
-    raw_clips_dir = cfg['PATHS']['MASKED_VIDEOS']
-    short_clips = []
-    for clip_class in os.listdir(raw_clips_dir):
-        clip_class_dir = os.path.join(raw_clips_dir, clip_class)
-        for clip in os.listdir(clip_class_dir):
-            # Get clip length.
-            l = get_clip_length(os.path.join(clip_class_dir, clip))
-            if l < 3.0:
-                short_clips.append(os.path.join(clip_class_dir, clip))
-    # Show the filenames of all clips less than the mini-clip window specified in the config file.
-    for clip in short_clips:
-        print(clip)
-    print(len(short_clips))
+def external_m_mode_peek(n, npz_dir, save_dir, pull_by_loc=True):
+    '''
+    Saves n of the M-modes into save_dir. Pulls approximately the same number of M-modes from each multi-center location
+    if pull_by_loc is set to True. Note: The M-modes are pulled from npz_dir.
+    :param n: Number of M-mode images to pull.
+    :param npz_dir: Directory from which to retrieve .npz files. These files are converted to M-modes. Absolute path.
+    :param save_dir: Directory to which to save the n M-modes. Absolute path.
+    :param pull_by_loc: Defaults to True. If True, then M-modes are evenly pulled by multi-center location.
+    '''
+    npzs = []
 
-    save_m_modes(npz_dir, mmode_dir)
+    # If pull_by_loc is True, then pull M-modes evenly by location.
+    if pull_by_loc:
+        num_clips = []
+        locs = cfg_full['EXTERNAL_VAL']['LOCATIONS']
+        num_loc = len(locs)
+        n_per_loc = n // num_loc
+        for i in range(num_loc):
+            num_clips.append(n_per_loc)
+        num_clips[0] += n - n_per_loc * num_loc
+
+        # Get n random .npzs to convert to M-modes. Do so evenly by location.
+        for i in range(len(num_clips)):
+            print(os.path.join(npz_dir, locs[i]))
+            for input_class in ['sliding', 'no_sliding']:
+                npzs_for_loc = glob.glob(os.path.join(npz_dir, locs[i], input_class, '*.npz'))
+                random.shuffle(npzs)
+                npzs_to_convert = npzs_for_loc[:(num_clips[i] // 2)]
+                npzs.extend(npzs_to_convert)
+
+    else:
+        for loc in cfg_full['EXTERNAL_VAL']['LOCATIONS']:
+            for input_class in ['sliding', 'no_sliding']:
+                npzs.extend(glob.glob(os.path.join(npz_dir, loc, input_class, '*.npz')))
+        random.shuffle(npzs)
+        npzs = npzs[:n]
+
+    if not os.path.exists(save_dir):
+        os.makedirs(save_dir)
+    else:
+        refresh_folder(save_dir)
+
+    # Temporarily store the .npzs in save_dir.
+    for file in npzs:
+        filename = file.split('\\')[-1]
+        shutil.copy(file, os.path.join(save_dir, filename))
+
+    for file in glob.glob(os.path.join(save_dir, '*.npz')):
+        n = np.load(file)
+        arr = (n['mmode'])
+        path_parts = file.split('\\')
+        save_path = os.path.join('\\'.join(path_parts[:-1]), path_parts[-1][:-4] + '.jpg')
+        cv2.imwrite(save_path, arr)
+
+    # Remove .npzs from M-mode directory.
+    for file in glob.glob(os.path.join(save_dir, '*.npz')):
+        os.remove(file)
+
+
+if __name__ == '__main__':
+    project_dir = '\\'.join(os.getcwd().split('\\')[:-2])
+    external_m_mode_peek(30, project_dir + cfg_full['EXTERNAL_VAL']['PATHS']['NPZS'],
+                         project_dir + '\\mmode_sample')
+    # raw_clips_dir = cfg['PATHS']['MASKED_VIDEOS']
+    # short_clips = []
+    # for clip_class in os.listdir(raw_clips_dir):
+    #     clip_class_dir = os.path.join(raw_clips_dir, clip_class)
+    #     for clip in os.listdir(clip_class_dir):
+    #         # Get clip length.
+    #         l = get_clip_length(os.path.join(clip_class_dir, clip))
+    #         if l < 3.0:
+    #             short_clips.append(os.path.join(clip_class_dir, clip))
+    # # Show the filenames of all clips less than the mini-clip window specified in the config file.
+    # for clip in short_clips:
+    #     print(clip)
+    # print(len(short_clips))
+    #
+    # save_m_modes(npz_dir, mmode_dir)

--- a/src/data/sql_utils.py
+++ b/src/data/sql_utils.py
@@ -3,13 +3,15 @@ import os
 import yaml
 import pandas as pd
 import datetime
+import time
 
 database_cfg = yaml.full_load(open(os.path.join(os.getcwd(), "database_config.yml"), 'r'))
 
 
 def get_clips_from_db(table_name, sliding=True):
     '''
-    Pulls clips from database using specified MySQL query.
+    Pulls clips from table specified by table_name. Specify whether to pull present or absent sliding clips using the
+    sliding parameter.
     :param table_name: Str, indicates location from the multi-center study for which to pull clips.
     :param sliding: Bool, set to True to pull present lung sliding clips. Set to False to pull absent lung sliding clips.
     '''
@@ -54,10 +56,11 @@ def get_clips_from_db(table_name, sliding=True):
 
 def add_date_to_filename(file):
     '''
-    Labels a file name with useful information about date and time.
+    Labels a file name with a Unix timestamp.
     :param file: name of file as string
-    :return labelled_filename: name of file joined with date and time info.
+    :return labelled_filename: name of file joined with date and time info (Unix format).
     '''
-    cur_date = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
-    labelled_filename = file + '_' + cur_date
+    cur_date = datetime.datetime.now()
+    cur_date = time.mktime(cur_date.timetuple())
+    labelled_filename = file + '_' + str(cur_date)
     return labelled_filename

--- a/src/data/sql_utils.py
+++ b/src/data/sql_utils.py
@@ -1,0 +1,63 @@
+import mysql.connector
+import os
+import yaml
+import pandas as pd
+import datetime
+
+database_cfg = yaml.full_load(open(os.path.join(os.getcwd(), "database_config.yml"), 'r'))
+
+
+def get_clips_from_db(table_name, sliding=True):
+    '''
+    Pulls clips from database using specified MySQL query.
+    :param table_name: Str, indicates location from the multi-center study for which to pull clips.
+    :param sliding: Bool, set to True to pull present lung sliding clips. Set to False to pull absent lung sliding clips.
+    '''
+    # Get database configs
+    user = database_cfg['USERNAME']
+    password = database_cfg['PASSWORD']
+    host = database_cfg['HOST']
+    db = database_cfg['DATABASE']
+
+    # Establish connection to database
+    cnx = mysql.connector.connect(user=user, password=password, host=host, database=db)
+
+    # initialize pleural_line_findings query condition
+    pleural_line_findings = " is null OR pleural_line_findings='thickened'"
+
+    # adjust pleural_line_findings query condition as needed
+    if table_name == 'clips_chile':
+        if sliding:
+            pleural_line_findings = "='' OR pleural_line_findings='thickened'"
+    if not sliding:
+        pleural_line_findings = "='absent_lung_sliding'"
+
+    # set up the MySQL query
+    query = "SELECT * FROM {} WHERE view='parenchymal' AND a_or_b_lines='a_lines'" \
+            " AND (quality NOT LIKE '%significant_probe_movement%' OR quality is null)" \
+            " AND (pleural_line_findings{}"\
+        .format(table_name, pleural_line_findings)
+
+    # If pulling Alberta data, ensure that these clips have been reviewed and are ready to use!
+    if table_name == 'clips_alberta':
+        query += ' AND reviewed=1 AND do_not_use=0'
+        if not sliding:
+            pleural_line_findings += "='absent_lung_sliding' OR pleural_line_findings='thickened|absent_lung_sliding'"
+
+    # Complete query syntax
+    query += ');'
+
+    # pull clips from the database into a DataFrame
+    clips_df = pd.read_sql(query, cnx)
+    return clips_df
+
+
+def add_date_to_filename(file):
+    '''
+    Labels a file name with useful information about date and time.
+    :param file: name of file as string
+    :return labelled_filename: name of file joined with date and time info.
+    '''
+    cur_date = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
+    labelled_filename = file + '_' + cur_date
+    return labelled_filename

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -149,7 +149,7 @@ def get_eval_results(model_path, test_df, metrics, save_pred_labels=True, verbos
         ids = pd.DataFrame(test_df['id'], columns=['id']).reset_index(drop=True)
         pred_label_df = pd.concat([ids, pred_labels_col, probs_col], axis=1)
 
-    conf_mtrx = confusion_matrix(y_true=test_df['label'], y_pred=np.rint(probs).astype(np.int))
+    conf_mtrx = confusion_matrix(y_true=test_df['label'], y_pred=np.rint(probs))
 
     results = []
     metric_names = []
@@ -215,15 +215,14 @@ def upsample_absent_sliding_data(train_df, upsample_df, prop, absent_pct, method
     '''
 
     no_upsampled_train_df = train_df
-    if len(upsample_df) != 0:
-        no_upsampled_train_df = train_df[~train_df['id'].isin(upsample_df['miniclip_id'])]
+    # if len(upsample_df) != 0:
+    #     no_upsampled_train_df = train_df[~train_df['id'].isin(upsample_df['miniclip_id'])]
 
     # Get sliding and no-sliding subsets of train_df.
     sliding_df = no_upsampled_train_df[no_upsampled_train_df['label'] == 1]
     no_sliding_df = no_upsampled_train_df[no_upsampled_train_df['label'] == 0]
 
     sliding_df = sliding_df.reset_index(drop=True)
-    no_sliding_df = no_sliding_df
 
     # Shuffle no_sliding_df. We do this to facilitate random duplicate up-sampling from the no-sliding dataframe.
     # I.e we draw miniclips to duplicate from a shuffled no-sliding df.
@@ -233,20 +232,15 @@ def upsample_absent_sliding_data(train_df, upsample_df, prop, absent_pct, method
     num_upsampled = int(absent_pct * (len(sliding_df) / (1 - absent_pct)))
 
     upsample_set = no_sliding_df.iloc[:(num_upsampled - len(no_sliding_df))]
-
-    # Put new upsample col and new ext data prop col here.
-    upsample_col = pd.DataFrame([1] * len(upsample_set), columns=['upsampled']).reset_index(drop=True)
     ext_data_props = pd.DataFrame([prop] * len(upsample_set), columns=['ext_data_prop']).reset_index(drop=True)
 
     upsample_ids = upsample_set['id']
     upsample_ids = pd.DataFrame({'miniclip_id': upsample_ids})
     upsample_ids = upsample_ids.reset_index(drop=True)
-    new_upsampled = pd.concat([ext_data_props, upsample_ids, upsample_col], axis=1)
-
+    new_upsampled = pd.concat([ext_data_props, upsample_ids], axis=1).reset_index(drop=True)
     new_upsampled_df = pd.concat([upsample_df, new_upsampled])
 
     no_sliding_df = pd.concat([no_sliding_df, upsample_set])
-    no_sliding_df.update(pd.DataFrame(upsample_col))
     print('Sliding: {}'.format(len(sliding_df)))
     print('No Sliding: {}'.format(len(no_sliding_df)))
     new_train_df = pd.concat([sliding_df, no_sliding_df])
@@ -278,6 +272,7 @@ class TAAFT:
         id in the fold on a new line.
         :param trial_folder: Absolute path to folder in which to place patient folds. Corresponds to a particular trial.
         '''
+
         sliding_df = self.mini_clip_df[self.mini_clip_df['label'] == 1]
         no_sliding_df = self.mini_clip_df[self.mini_clip_df['label'] == 0]
 
@@ -303,159 +298,117 @@ class TAAFT:
         elif overwrite:
             open(folds_path, "w").close()
 
-        # Populate the file to store ids by fold.
-        folds = []
-        cur_fold = []
-
         # Keep track of the desired sizes for each fold. Since not all folds will be of the same size in terms
         # of patient ids, this eliminates the need to dynamically compute each fold size.
         n_folds = cfg['FOLD_SAMPLE']['NUM_FOLDS']
         fold_sizes = [len(sliding_ids) // n_folds] * n_folds
         fold_sizes[-1] += len(sliding_ids) % n_folds
 
-        # Note: the code block above assumes that, if the number of sliding ids is not perfectly divisible by the
-        # desired number of folds, then we make one fold slightly bigger than the rest. This must be modified if
-        # we choose not to keep the smaller "leftover" fold.
+        folds = []
+        sliding_count = [0] * n_folds
+        no_sliding_count = [0] * n_folds
 
-        sliding_count = 0
-        sliding = []
-        no_sliding = []
+        folds_to_supply = []
 
-        print("Sampling folds...\n")
-        # Populate each fold with sliding ids
-        cur_fold_num = 0
-        for size in fold_sizes:
-            for i in range(size):
-                cur_id = sliding_ids[-1]
-                sliding_ids = sliding_ids[:-1]
-                # Save the portion of the sliding df that contains these patient ids. Save by mini-clip id.
-                clips_by_id = sliding_df[sliding_df['patient_id'] == cur_id]['id']
-                sliding_count += len(clips_by_id)
-                cur_fold.append(clips_by_id)
-            # Each fold is represented as a separate DataFrame. The folds variable is a list of pd.DataFrames.
-            cur_fold = pd.concat(cur_fold)
-            folds.append(cur_fold)
-            cur_fold = []
-            cur_fold_num += 1
-            sliding.append(sliding_count)
-            sliding_count = 0
+        for i in range(n_folds):
+            fold_end = min(fold_sizes[i], len(sliding_ids))
+            cur_ids = sliding_ids[:fold_end]
+            sliding_ids = sliding_ids[fold_sizes[i]:]
+            cur_fold_sliding = sliding_df[sliding_df['patient_id'].isin(cur_ids)]['id']
+            cur_fold_no_sliding = no_sliding_df[no_sliding_df['patient_id'].isin(cur_ids)]['id']
+            sliding_count[i] += len(cur_fold_sliding)
+            no_sliding_count[i] += len(cur_fold_no_sliding)
+            if len(cur_fold_no_sliding) == 0:
+                folds_to_supply.append(i)
+            no_sliding_df = no_sliding_df[~no_sliding_df['patient_id'].isin(cur_ids)]
+            folds.append(pd.concat([cur_fold_sliding, cur_fold_no_sliding]))
 
-        num_folds = len(folds)
+        no_sliding_ids = no_sliding_df['patient_id'].values
+        folds_with_all_sliding = len(folds_to_supply) if len(folds_to_supply) > 0 else n_folds
+        no_sliding_to_add = [len(no_sliding_ids) // folds_with_all_sliding] * folds_with_all_sliding
+        for i in range(len(no_sliding_ids) % folds_with_all_sliding):
+            no_sliding_to_add[i] += 1
 
-        # Distribute non-sliding ids across folds. This is done in a roulette-like manner so that the ratio of negative
-        # to positive classes in each fold is preserved.
-        i = 0
-        while True:
-            if len(no_sliding_ids) == 0:
-                break
-            cur_id = no_sliding_ids[-1]
-            no_sliding_ids = no_sliding_ids[:-1]
-            clips_by_id = no_sliding_df[no_sliding_df['patient_id'] == cur_id]['id']
-            no_sliding_count = len(clips_by_id)
-            temp = folds[i % num_folds]
-            folds[i % num_folds] = pd.concat([temp, clips_by_id])
-            if i < num_folds:
-                no_sliding.append(no_sliding_count)
-            else:
-                no_sliding[i % num_folds] += no_sliding_count
-            i += 1
+        for i, j in zip(no_sliding_to_add, folds_to_supply):
+            folds[j] = pd.concat([folds[j], no_sliding_df.head(i)])
+            no_sliding_df = no_sliding_df.tail(len(no_sliding_df) - i)
 
-        for i in range(num_folds):
-            print("Fold {}: {} clips with lung sliding, {} clips without lung sliding. Negative:Positive ~ {}"
-                  .format(i + 1, sliding[i], no_sliding[i], round(sliding[i] / no_sliding[i], 3)))
+        ratios = []
+        for i in range(n_folds):
+            ratio = no_sliding_count[i] / sliding_count[i]
+            ratios.append(ratio)
+            print('Fold {}: {} sliding, {} no sliding. Absent to present ratio: {}'
+                  .format(i + 1, sliding_count[i], no_sliding_count[i], ratio))
 
-        avg_neg_to_pos_ratio = sum([sliding[i] / no_sliding[i] for i in range(len(folds))]) / len(folds)
-        print("Average negative:positive ratio ~ {}\n".format(round(avg_neg_to_pos_ratio)))
+        print('Average absent to present ratio: {}'.format(sum(ratios) / n_folds))
 
         # Write the folds to the fold file:
         if cfg['FOLD_SAMPLE']['OVERWRITE_FOLDER']:
             refresh_folder(os.getcwd() + cfg['PATHS']['FOLDS'])
         write_folds_to_csv(folds, folds_path)
 
-        print("Sampling complete with seed = " + str(cfg['FOLD_SAMPLE']['SEED']) +
-              ". Folds saved to " + folds_path + ".")
-
-    def finetune_single_trial(self, trial_folder, hparams=None, lazy=True):
+    def finetune_single_trial(self, trial_folder, hparams=None, lazy=True, upsample=True):
         '''
         Performs a single fine-tuning trial. Fine-tunes a model on external clip data, repeatedly augmenting external
         data slices to a training set until all external data has been used for training.
         :param trial_folder: Absolute path to folder in which to place metrics for current trial.
         :param hparams: Specifies the set of hyperparameters for fine-tuning the model.
         :param lazy: When True, trial will terminate once model performance exceeds minimum thresholds.
+        :param upsample: When True, upsamples absent sliding mini-clips in each training set during fine-tuning.
         '''
+
+        original_model_path = os.path.join(os.getcwd(), cfg_full['PREDICT']['MODEL'])
+        metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
 
         # Set up result directories for given trial; read values from config file.
         model_out_dir = os.path.join(trial_folder, 'models')
         if not os.path.exists(model_out_dir):
             os.makedirs(model_out_dir)
 
+        # Set up the labelled external dataframe for augmenting the training data.
+        ext_df = self.mini_clip_df
+
+        # This df will store trial results.
+        trial_results_df = pd.DataFrame([])
+
+        # Get results for original model before fine-tuning.
+        res_df, _ = get_eval_results(original_model_path, ext_df, metrics)
+        trial_results_df = pd.concat([trial_results_df, res_df])
+        original_model = load_model(original_model_path, compile=False)
+        original_model.save(os.path.join(model_out_dir, 'model_0.0_percent_train'))
+
         model_name = cfg_full['TRAIN']['MODEL_DEF'].lower()
         hparams = cfg_full['TRAIN']['PARAMS'][model_name.upper()] if hparams is None else hparams
 
-        upsample_miniclips_path = os.path.join(trial_folder, 'upsample_miniclips.csv')
-        upsample_df = pd.DataFrame([], columns=['ext_data_prop', 'miniclip_id', 'upsampled'])
+        model_def = cfg_full['TRAIN']['MODEL_DEF'].upper()
+        model_config = cfg_full['TRAIN']['PARAMS'][model_def]
 
         # Retrieve patient folds (stored by clip ids).
         filename = glob.glob(os.path.join(trial_folder, 'folds*.csv'))[0]
-        folds_file = os.path.join(trial_folder, filename)
-        folds = pd.read_csv(folds_file)
-        cur_fold = []
-        # stores the folds extracted from the txt file. Each fold is a pd.DataFrame.
-        fold_list = []
-
-        for i in range(1, cfg['FOLD_SAMPLE']['NUM_FOLDS'] + 1):
-            fold_list.append(folds[folds['fold_number'] == i])
-
-        print("Retrieved {} external patient folds. The lengths of each fold are: ".format(len(fold_list)),
-              [len(fold) for fold in fold_list])
-
-        # set up the labelled external dataframe for augmenting the training data
-        labelled_ext_df_dir = os.path.join(os.getcwd() + cfg['PATHS']['CSV_OUT'], 'labelled_external_dfs')
-        ext_df = pd.read_csv(glob.glob(os.path.join(labelled_ext_df_dir, '*.csv'))[0])
+        folds = pd.read_csv(filename)
 
         train_df = pd.DataFrame([])
 
-        print('Setup complete')
+        # If absent sliding mini-clips are to be upsampled, create a df for saving these upsampled mini-clips.
+        upsample_df = pd.DataFrame([])
+        upsample_miniclips_path = os.path.join(trial_folder, 'upsample_miniclips.csv')
 
-        # Fine-tuning trial starts here.
-        cur_fold_num = 0
-        num_folds_added = 0  # number of external data slices that have been added to the training set
         min_test_size = int(len(ext_df) * cfg['MIN_TEST_SIZE'])
 
-        # # After .npz conversion, clip ids are followed by indices. Ignore these indices for patient id retrieval by
-        # # clip id.
-        # original_clip_ids = pd.DataFrame(ext_df['id'].str[:-2], columns=['id'])
-        # clip_id_count = original_clip_ids.groupby('id').transform('count')
-        # original_clip_ids = pd.concat([original_clip_ids, clip_id_count], axis=1)
-        # ext_df = ext_df.rename(columns={'id': 'miniclip_id'})
-        # ext_df = pd.concat([original_clip_ids, ext_df], axis=1)
-        
-        trial_results_df = pd.DataFrame([])
-
-        # This will later become a column for external data proportions in the trial result df.
+        cur_fold_num = 0
         props = [0]
+        while len(ext_df) > min_test_size:
+            print('Fine-tuning: {} of {} external data slices...'
+                  .format(cur_fold_num + 1, cfg['FOLD_SAMPLE']['NUM_FOLDS']))
+            fold_to_add = folds[folds['fold_number'] == cur_fold_num + 1]
+            train_df = pd.concat([train_df, ext_df[ext_df['id'].isin(fold_to_add['id'])]])
+            ext_df = ext_df[~ext_df['id'].isin(fold_to_add['id'])]
 
-        # Loop until external testing set has reached minimum size.
-        while len(ext_df) >= min_test_size:
-            print('\n======================= FINE-TUNING ON {} OF {} SLICES OF EXTERNAL DATA ========================\n'
-                  .format(str(num_folds_added + 1), len(fold_list)))
-            # Evaluate the model on the external test set. Note that we load the original pre-finetuned model at each
-            # iteration to minimize co-dependence between runs of a given trial.
-            print('Evaluating model performance before fine-tuning...')
-            # Can change these metrics as necessary
+            # Model starts out as the original model, but then gets fine-tuned.
+            model = original_model
             metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
 
-            # Get evaluation results on model before fine-tuning.
-            original_model_path = os.path.join(os.getcwd(), cfg_full['PREDICT']['MODEL'])
-            res_df, _ = get_eval_results(original_model_path, ext_df, metrics)
-
-            model = load_model(original_model_path, compile=False)
-
-            # Read original model params from config file. Store into model_config.
-            model_def = cfg_full['TRAIN']['MODEL_DEF'].upper()
-            model_config = cfg_full['TRAIN']['PARAMS'][model_def]
-
-            # Freeze layers
+            # Freeze some layers.
             freeze_cutoff = -1 if model_config['BLOCKS_FROZEN'] == 0 else model_config['BLOCKS_FROZEN']
             for i in range(len(model.layers)):
                 if i <= freeze_cutoff:
@@ -464,47 +417,26 @@ class TAAFT:
                 elif ('batch' in model.layers[i].name) or ('bn' in model.layers[i].name):
                     model.layers[i].trainable = False
 
-            # Save the model's loss/sens/spec results from before fine-tuning.
-            if num_folds_added == 0:
-                trial_results_df = pd.concat([trial_results_df, res_df])
-                # Save the original model in the trial's model directory
-                if not lazy or check_performance(res_df):
-                    print('Saving original model...')
-                    model.save(os.path.join(model_out_dir, 'model_0.0_percent_train'))
-                    if lazy:
-                        return
+            if upsample:
+                # cur_ext_prop is the current external data proportion used for training
+                cur_ext_prop = (cur_fold_num + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS']
+                train_df, upsample_df = upsample_absent_sliding_data(train_df, upsample_df, cur_ext_prop, 0.25)
 
-            # Set aside some external data to be added to the existing training data.
-            add_set = fold_list[num_folds_added]
-            add_df = ext_df[ext_df['id'].isin(add_set['id'])]
-
-            # Remove the newly-added training data from the external dataset. Becomes the new testing set.
-            ext_df = ext_df[~ext_df['id'].isin(add_df['id'])]
-
-            # Update the training dataset with the new patient-wise fold. Up-sample as necessary.
-            train_df = pd.concat([train_df, add_df])
-
-            train_df, upsample_df = upsample_absent_sliding_data(train_df, upsample_df,
-                                                                 (num_folds_added + 1) / len(fold_list), 0.25)
-
-            if os.path.exists(upsample_miniclips_path):
-                os.remove(upsample_miniclips_path)
-            upsample_df.to_csv(upsample_miniclips_path)
+                # Update the upsampled mini-clips .csv file.
+                if os.path.exists(upsample_miniclips_path):
+                    os.remove(upsample_miniclips_path)
+                upsample_df.to_csv(upsample_miniclips_path)
 
             # Shuffle the training data.
-            train_df.sample(frac=1).reset_index(drop=True)
-
-            # Print the ratio of external train vs external test data
-            print('Train: {}\nTest: {}'.format(len(train_df), len(ext_df)))
+            train_df.sample(frac=1)
 
             # Create training and validation sets for fine-tuning.
             sub_val_df = train_df.tail(int(len(train_df) * cfg['FINETUNE']['VAL_SPLIT']))
             sub_train_df = train_df[~train_df['id'].isin(sub_val_df['id'])]
 
-            # Model fine-tuning.
-            print('Fine-tuning...')
+            print('Train: {}\nTest: {}'.format(len(train_df), len(ext_df)))
 
-            # The following code was borrowed from src/models/models.py.
+            # ========== The following code was borrowed from src/models/models.py. ====================================
             # Fine-tune the model
             model_def_fn, preprocessing_fn = get_model(cfg['FINETUNE']['MODEL_DEF'])
 
@@ -531,7 +463,7 @@ class TAAFT:
             class_weight = {0: weight_for_0, 1: weight_for_1}
 
             # Refresh the TensorBoard directory
-            tensorboard_path = cfg_full['TRAIN']['PATHS']['TENSORBOARD']
+            tensorboard_path = os.path.join(cfg_full['TRAIN']['PATHS']['TENSORBOARD'], add_date_to_filename('log'))
             if not os.path.exists(tensorboard_path):
                 os.makedirs(tensorboard_path)
 
@@ -553,7 +485,7 @@ class TAAFT:
 
             # Creating a ModelCheckpoint for saving the model
             save_cp = ModelCheckpoint(os.path.join(model_out_dir, 'model_'
-                                                   + str((num_folds_added + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS'])
+                                                   + str((cur_fold_num + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS'])
                                                    + '_percent_train'),
                                       save_best_only=cfg_full['TRAIN']['SAVE_BEST_ONLY'])
 
@@ -592,50 +524,49 @@ class TAAFT:
             metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
             current_results, _ = get_eval_results(current_model_path, ext_df, metrics)
             trial_results_df = pd.concat([trial_results_df, current_results])
-            props.append((num_folds_added + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS'])
+            props.append((cur_fold_num + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS'])
 
             # If the fine-tuned model now performs well on the test set, terminate the trial early.
             perf_check = check_performance(current_results)
             if perf_check and lazy:
                 break
 
-            # # Remove model if performance not satisfactory.
-            # elif not perf_check:
-            #     rmtree(current_model_path)
-
             gc.collect()
             tf.keras.backend.clear_session()
             del model
 
-            if len(ext_df) < min_test_size:
-                print('EVALUATING PREVIOUS MODELS ON MINIMUM SIZED TEST SET...')
-
-                # Set up column in trial results df to specify whether results are for fixed or variable sized test set.
-                var_size_test_set = [1] * (num_folds_added + 1)
-                # Add an extra 1 in the test set size column. This is for when we evaluated the original (non finetuned)
-                # model on the external dataset.
-                var_size_test_set.append(1)
-
-                # For each previous model, get results on minimum (fixed) size test set.
-                for prev_model in os.listdir(model_out_dir):
-                    prev_model_path = os.path.join(model_out_dir, prev_model)
-                    metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
-                    fixed_test_set_eval, _ = get_eval_results(prev_model_path, ext_df, metrics)
-                    trial_results_df = pd.concat([trial_results_df, fixed_test_set_eval])
-                    var_size_test_set.append(0)
-
-                # Concatenate fixed/variable size test set column with the trial result df.
-                var_size_test_set = pd.DataFrame(var_size_test_set, columns=['variable_sized_test_set'])\
-                    .reset_index(drop=True)
-                props.extend(props)
-                props = pd.DataFrame(props, columns=['ext_data_prop']).reset_index(drop=True)
-                trial_results_df = trial_results_df.reset_index(drop=True)
-                trial_results_df = pd.concat([var_size_test_set, props, trial_results_df], axis=1)
-                trial_results_df.to_csv(os.path.join(trial_folder, 'results.csv'))
+            # ==========================================================================================================
 
             # Update loop counters.
             cur_fold_num += 1
-            num_folds_added += 1
+            props.append(cur_fold_num / cfg['FOLD_SAMPLE']['NUM_FOLDS'])
+
+        print('EVALUATING PREVIOUS MODELS ON MINIMUM SIZED TEST SET...')
+
+        # Set up column in trial results df to specify whether results are for fixed or variable sized test set.
+        var_size_test_set = [1] * (cur_fold_num)
+
+        # Add an extra 1 in the test set size column. This is for when we evaluated the original (non finetuned)
+        # model on the external dataset.
+        var_size_test_set.append(1)
+
+        # For each previous model, get results on minimum (fixed) size test set.
+        for prev_model in os.listdir(model_out_dir):
+            prev_model_path = os.path.join(model_out_dir, prev_model)
+            metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
+            fixed_test_set_eval, _ = get_eval_results(prev_model_path, ext_df, metrics)
+            trial_results_df = pd.concat([trial_results_df, fixed_test_set_eval])
+            var_size_test_set.append(0)
+
+        # Concatenate fixed/variable size test set column with the trial result df.
+        var_size_test_set = pd.DataFrame(var_size_test_set, columns=['variable_sized_test_set']) \
+            .reset_index(drop=True)
+        props.extend(props)
+        props = pd.DataFrame(props, columns=['ext_data_prop']).reset_index(drop=True)
+        trial_results_df = trial_results_df.reset_index(drop=True)
+        trial_results_df = pd.concat([var_size_test_set, props, trial_results_df], axis=1)
+        trial_results_df.to_csv(os.path.join(trial_folder, 'results.csv'))
+
 
     def finetune_multiple_trials(self):
         '''

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -463,11 +463,6 @@ class TAAFT:
                         tf.summary.text(name='Early Stopping', data=tf.convert_to_tensor('Training stopped early'),
                                         step=0)
 
-            # for metric in history.history.keys():
-            #     if metric in metrics_df.columns:
-            #         metric_values = history.history[metric]
-            #         metrics_df.loc[metric] = sum(metric_values) / len(metric_values)
-
             test_results = model.evaluate(test_set)
             print(test_results)
 

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -151,7 +151,7 @@ def get_eval_results(model_path, test_df, metrics, verbose=True):
                                                 gamma=model_config['GAMMA']),
                   optimizer=optimizer, metrics=metrics)
     pred_labels, probs = predict_set(model, test_df)
-    conf_mtrx = confusion_matrix(y_true=pred_labels, y_pred=np.rint(probs).astype(np.int))
+    conf_mtrx = confusion_matrix(y_true=test_df['label'], y_pred=np.rint(probs).astype(np.int))
 
     results = []
     metric_names = []
@@ -528,6 +528,7 @@ class TAAFT:
 
             # Add evaluation results for the current model on the current test set to the trial results df.
             current_model_path = os.path.join(model_out_dir, os.listdir(model_out_dir)[-1])
+            metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
             current_results = get_eval_results(current_model_path, ext_df, metrics)
             trial_results_df = pd.concat([trial_results_df, current_results])
             props.append((num_folds_added + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS'])
@@ -557,6 +558,7 @@ class TAAFT:
                 # For each previous model, get results on minimum (fixed) size test set.
                 for prev_model in os.listdir(model_out_dir):
                     prev_model_path = os.path.join(model_out_dir, prev_model)
+                    metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
                     fixed_test_set_eval = get_eval_results(prev_model_path, ext_df, metrics)
                     trial_results_df = pd.concat([trial_results_df, fixed_test_set_eval])
                     var_size_test_set.append(0)
@@ -568,7 +570,7 @@ class TAAFT:
                 props = pd.DataFrame(props, columns=['ext_data_prop']).reset_index(drop=True)
                 trial_results_df = trial_results_df.reset_index(drop=True)
                 trial_results_df = pd.concat([var_size_test_set, props, trial_results_df], axis=1)
-                trial_results_df.to_csv(os.path.join(trial_folder, 'sens_spec_results.csv'))
+                trial_results_df.to_csv(os.path.join(trial_folder, 'sens_spec_results_trial_1.csv'))
 
             # Update loop counters.
             cur_fold_num += 1

--- a/src/make_splits.py
+++ b/src/make_splits.py
@@ -110,6 +110,8 @@ if (s > 1.0) or (train_prop < 0) or (val_prop < 0) or (test_prop < 0):
 
 # CSV paths
 csv_path = os.path.join(os.getcwd(), 'data/', cfg['PREPROCESS']['PATHS']['CSVS_OUTPUT'])
+if cfg['PREPROCESS']['PATHS']['CSVS_OUTPUT'].split('\\')[0] == 'generalizability':
+    csv_path = os.path.join(os.getcwd(), cfg['PREPROCESS']['PATHS']['CSVS_OUTPUT'])
 
 flow = cfg['PREPROCESS']['PARAMS']['FLOW']
 
@@ -149,11 +151,11 @@ else:
     sliding_df = df_splits_two_stream(sliding_df, flow_sliding_df, train_prop, val_prop, test_prop)
     no_sliding_df = df_splits_two_stream(no_sliding_df, flow_no_sliding_df, train_prop, val_prop, test_prop)
 
-# Add label to dataframes. We consider absent lung sliding to be the "positive" class here, hence the label of 1.
-l0 = [0] * len(sliding_df)
-sliding_df['label'] = l0
-l1 = [1] * len(no_sliding_df)
-no_sliding_df['label'] = l1
+# Add label to dataframes.
+l1 = [1] * len(sliding_df)
+sliding_df['label'] = l1
+l0 = [0] * len(no_sliding_df)
+no_sliding_df['label'] = l0
 
 # Add file path to dataframes
 npz_dir = ''
@@ -210,7 +212,7 @@ val_df = final_df[final_df['split']==1]
 test_df = final_df[final_df['split']==2]
 
 # Write each to csv
-csv_dir = cfg['TRAIN']['PATHS']['CSVS']
+csv_dir = os.getcwd() + cfg['TRAIN']['PATHS']['CSVS']
 if not os.path.exists(csv_dir):
     os.makedirs(csv_dir)
 

--- a/src/make_splits.py
+++ b/src/make_splits.py
@@ -149,11 +149,11 @@ else:
     sliding_df = df_splits_two_stream(sliding_df, flow_sliding_df, train_prop, val_prop, test_prop)
     no_sliding_df = df_splits_two_stream(no_sliding_df, flow_no_sliding_df, train_prop, val_prop, test_prop)
 
-# Add label to dataframes
-l1 = [1] * len(sliding_df)
-sliding_df['label'] = l1
-l0 = [0] * len(no_sliding_df)
-no_sliding_df['label'] = l0
+# Add label to dataframes. We consider absent lung sliding to be the "positive" class here, hence the label of 1.
+l0 = [0] * len(sliding_df)
+sliding_df['label'] = l0
+l1 = [1] * len(no_sliding_df)
+no_sliding_df['label'] = l1
 
 # Add file path to dataframes
 npz_dir = ''


### PR DESCRIPTION
Added parameter in config.yml for minimum external test set size. Added functions to save fine-tuning results into .csv format and plot results.

### Minor Update to Methodology ###

In addition to fine-tuning the classifier on training sets made from each of 20%, 40%, and 60% of the external data and evaluating on 80%, 60%, and 40%, respectively, we evaluate the saved 20% and 40% models on the minimum test set size, which is 40% of the external dataset. For clarity, see the figure below (this is what happens in a single trial):

![method_schematic](https://user-images.githubusercontent.com/72673376/181834490-aa39c479-d86c-4260-89de-53ca763084d0.png)
Figure provided by @delaneysmith22.