### PR TITLE
Updates to finetuning functionality for the multicenter study

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ results/
 !results/experiments/.gitkeep
 !results/metrics/.gitkeep
 !results/predictions/.gitkeep
+data/
 
 img/
 !img/heatmaps/.gitkeep

--- a/config.yml
+++ b/config.yml
@@ -270,7 +270,7 @@ EXPLAINABILITY:
 EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa', 'alberta']  # List of centers involved in the multi-center study.
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
-  NUM_TRIALS: 5  # Specify the number of fine-tuning trials.
+  NUM_TRIALS: 1  # Specify the number of fine-tuning trials.
   MIN_TEST_SIZE: 0.5  # Specify the minimum proportion of external data to set aside for testing purposes.
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
@@ -293,12 +293,12 @@ EXTERNAL_VAL:
     OVERWRITE_MODEL_DIR: True  # Set True if you want to clear existing contents in the model folder.
     METRIC_THRESHOLDS:  # Thresholds for assessing the performance of a fine-tuned model.
       LOWER_BOUNDS:
-        SENSITIVITY: 90.1
-        SPECIFICITY: 79.3
+        SENSITIVITY: 79.3
+        SPECIFICITY: 90.1
       UPPER_BOUNDS:
     MIN_DELTA: 0.0001
     VAL_SPLIT: 0.2 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 1
+    EPOCHS: 100
     PRED_PROBS:
       SAVE_PRED_PROBABILITIES: True # Set to True to save prediction labels for each clip when evaluating fine-tuned models.
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.

--- a/config.yml
+++ b/config.yml
@@ -16,7 +16,7 @@ PREPROCESS:
     SMOOTHING: False  # Optional Median filter applied.
     SMOOTHING_KERNEL_SIZE: 5  # Integer, kernel size of square smoothing kernel filter - MUST be odd.
     SHUFFLE: True # If you want to randomize the videos downloaded.
-    RANDOM_SEED: 1 # If SHUFFLE=False, this does nothing. Otherwise, this is the seed for shuffling.
+    RANDOM_SEED: 4 # If SHUFFLE=False, this does nothing. Otherwise, this is the seed for shuffling.
     SLIDING_PROPORTION: 1  # Proportion of sliding clips from database to obtain.
     NO_SLIDING_PROPORTION: 1  # Proportion of absent sliding clips from database to obtain.
     M_MODE_WIDTH: 180 # width of m-mode image
@@ -36,7 +36,7 @@ PREPROCESS:
     CSVS_OUTPUT: 'generalizability\csvs\alberta'  # Path to any CSVs that are generated / taken from the database.
     NPZ: 'generalizability\npzs\alberta'  # Path to the mini-clip videos.
     FLOW_NPZ: 'flow_npzs\'  # Path to the .npzs containing optical flow mini-clips.
-    MASKING_TOOL: '\results\data\auto_masking_deeper.h5'  # Path to the masking tool. Currently only works with the older version!!!
+    MASKING_TOOL: 'auto_masking_deeper.h5'  # Path to the masking tool. Currently only works with the older version!!!
 
     # EXTRA refers to the first infusion of negative additions, which at the time of writing is kept separate
     # from the main resources from the dataset - this could change at any time. We only sometimes use them.
@@ -97,7 +97,7 @@ TRAIN:
       LR_DECAY_VAL: 0.05642  # Learning rate decay
       LR_DECAY_EPOCH: 15 # Epoch to start lr decay
       DROPOUT: 0.2151 # Dropout probability
-      LAYERS_FROZEN: 118 #161 # Number of blocks to freeze - MUST be 0 or positive
+      LAYERS_FROZEN: 161 #118 #161 # Number of blocks to freeze - MUST be 0 or positive
       L2_REG: 0.008629 # L2 regularization penalty
       WEIGHT_INITIALIZER: 'he_normal'  # Method to initialize weights for convolutional and FC layers - see https://www.tensorflow.org/api_docs/python/tf/keras/initializers
       ALPHA: 0.105 # focal loss parameter
@@ -275,7 +275,7 @@ EXTERNAL_VAL:
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
-    NPZS: '\generalizability\npzs'
+    NPZS: 'src\data\generalizability\npzs'
     MMODES: '\generalizability\mmodes'  # Path to external data M-mode images.
     CSV_OUT: '\generalizability\csvs'  # Path to external data csvs.
     MODEL_OUT: '\generalizability\results\models'  # Path to fine-tuned models.
@@ -284,7 +284,7 @@ EXTERNAL_VAL:
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments'
   FOLD_SAMPLE:
-    SEED: 3  # Seed for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
+    SEED: 4  # Seed for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     NUM_FOLDS: 5  # Number of desired external patient slices for augmenting training data during fine-tuning.
   FINETUNE:
     MODEL_DEF: 'efficientnet'  # Set this equal to the model definition string used for the pre-trained model.

--- a/config.yml
+++ b/config.yml
@@ -56,7 +56,7 @@ TRAIN:
   M_MODE_SLICE_SAMPLE: 15 # for 'brightest_vertical_sum_sampled', number of slices to randomly sample (top k brightest sums)
   MIXED_PRECISION: False
   OUTPUT_BIAS: False  # A class imbalance technique - whether or not to bias the model (output head) prior to training.
-  PATIENCE: 12  # The number of consecutive epochs with val_loss not improving, after which the model halts training.
+  PATIENCE: 6  # The number of consecutive epochs with val_loss not improving, after which the model halts training.
   MODEL_DEF: 'efficientnet'  # Check models.py for the current list of possible values (which is also where you would create a custom one).
   SAVE_BEST_ONLY: True  # Whether or not to only save the 'best' model, according to validation loss.
 
@@ -282,7 +282,7 @@ EXTERNAL_VAL:
     CSVS_SPLIT: '\generalizability\csvs_split'  # Path to train-test-val splits for external data.
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments'
-    TRIALS: '\generalizability\results\trials'
+    TRIALS: '\generalizability\results\experiments\trials'
     PLOTS: '\generalizability\results\experiments\plots'
   FOLD_SAMPLE:
     SEED: 42069  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
@@ -298,7 +298,7 @@ EXTERNAL_VAL:
         SPECIFICITY: 79.3
       UPPER_BOUNDS:
     VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 50
+    EPOCHS: 100
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.

--- a/config.yml
+++ b/config.yml
@@ -97,7 +97,7 @@ TRAIN:
       LR_DECAY_VAL: 0.05642  # Learning rate decay
       LR_DECAY_EPOCH: 15 # Epoch to start lr decay
       DROPOUT: 0.2151 # Dropout probability
-      BLOCKS_FROZEN: 220 # Number of blocks to freeze - MUST be 0 or positive
+      LAYERS_FROZEN: 220 # Number of blocks to freeze - MUST be 0 or positive
       L2_REG: 0.008629 # L2 regularization penalty
       WEIGHT_INITIALIZER: 'he_normal'  # Method to initialize weights for convolutional and FC layers - see https://www.tensorflow.org/api_docs/python/tf/keras/initializers
       ALPHA: 0.105 # focal loss parameter
@@ -252,7 +252,7 @@ CROSS_VAL:
             'false_positives', 'false_negatives'] # metrics to store in output csv
 
 PREDICT:
-  MODEL: 'results/models/efficientnet/20220325-190905/'  # Trained model used to generate predictions
+  MODEL: 'results/models/final_holdout_model/20220325-190905/'  # Trained model used to generate predictions
   TEST_DF: 'csvs_split/test.csv' # table of NPZs to generate predictions for
   PREDICTIONS_OUT: '../results/predictions'
 
@@ -264,14 +264,14 @@ EXPLAINABILITY:
   PATHS:
     NPZ: 'data/npzs/'  # Directory holding NPZs that heatmaps can be generated for.
     NPZ_DF: 'csvs_split/test.csv'  # Table of mini-clips that heatmaps can be generated for.
-    MODEL: 'results/models/efficientnet/20220325-190905'  # Trained model used to generate heatmaps.
+    MODEL: 'results/models/final_holdout_model/20220325-190905'  # Trained model used to generate heatmaps.
     FEATURE_HEATMAPS: 'feature_heatmaps/'  # Output directory for heatmap videos.
 
 EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa', 'alberta']  # List of centers involved in the multi-center study.
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
-  NUM_TRIALS: 1  # Specify the number of fine-tuning trials.
-  MIN_TEST_SIZE: 0.5  # Specify the minimum proportion of external data to set aside for testing purposes.
+  NEW_EXPERIMENT: True   # If set to True, creates a new folder for trial artefacts.
+  FIXED_TEST_SIZE: 0.4  # Specify the minimum proportion of external data to set aside for testing purposes.
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
@@ -284,9 +284,7 @@ EXTERNAL_VAL:
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments'
   FOLD_SAMPLE:
-    SEED: 1738  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
-    # There is one seed for each trial; insert or remove (or change) seeds as necessary/desired.
-    OVERWRITE_FOLDER: True  # Set this to True if you want to overwrite existing fold .txt files.
+    SEED: 3431  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     NUM_FOLDS: 5  # Number of desired external patient slices for augmenting training data during fine-tuning.
   FINETUNE:
     MODEL_DEF: 'efficientnet'  # Set this equal to the model definition string used for the pre-trained model.
@@ -303,5 +301,6 @@ EXTERNAL_VAL:
       SAVE_PRED_PROBABILITIES: True # Set to True to save prediction labels for each clip when evaluating fine-tuned models.
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
+    MINORITY_FRAC: 0.25 # If minority upsampling, this is the desired fraction of the minority class in the training set
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.
   PLOT_METRICS: ['loss', 'sensitivity', 'specificity']  # Specify metrics for which to generate plots (for each trial and trial-wise average).

--- a/config.yml
+++ b/config.yml
@@ -283,8 +283,6 @@ EXTERNAL_VAL:
     CSVS_SPLIT: '\generalizability\csvs_split'  # Path to train-test-val splits for external data.
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments'
-    TRIALS: '\generalizability\results\experiments\trials'
-    PLOTS: '\generalizability\results\experiments\plots'
   FOLD_SAMPLE:
     SEED: 42069  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     # There is one seed for each trial; insert or remove (or change) seeds as necessary/desired.

--- a/config.yml
+++ b/config.yml
@@ -71,7 +71,7 @@ TRAIN:
   # Parameters for augmentation and model-training specifics.
   PARAMS:
     EPOCHS: 40  # Maximum number of epochs to train the model for.
-    BATCH_SIZE: 40  # Integer to set the batch size. If you're running into memory errors, you'll have to lower this. Set this to 1 for GRADCAM.
+    BATCH_SIZE: 25  # Integer to set the batch size. If you're running into memory errors, you'll have to lower this. Set this to 1 for GRADCAM.
     SHUFFLE: True  # Boolean, whether to shuffle the training set or not.
     INCREASE: False  # Boolean, whether to oversample the minority class (assumed to be the negative class) or not.
     AUGMENTATION_CHANCE: 0.8  # Probability to augment an incoming batch.

--- a/config.yml
+++ b/config.yml
@@ -269,7 +269,7 @@ EXPLAINABILITY:
 
 EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa', 'alberta']  # List of centers involved in the multi-center study.
-  DATA_CHARACTERISTICS: ['clip_id','probe','location','patient_age','sex','depth_cat','manufacturer']
+  DATA_CHARACTERISTICS: ['probe','location','patient_age','sex','depth_cat','manufacturer']
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
   NEW_EXPERIMENT: True   # If set to True, creates a new folder for trial artefacts.
   FIXED_TEST_SIZE: 0.4  # Specify the minimum proportion of external data to set aside for testing purposes.
@@ -284,9 +284,9 @@ EXTERNAL_VAL:
     CSVS_SPLIT: '\generalizability\csvs_split'  # Path to train-test-val splits for external data.
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments\300922'
-    DATA_CHARACTERISTICS: 'data/generalizability/external_data_with_characteristics.csv'
+    DATA_CHARACTERISTICS: 'data\generalizability\external_data_with_characteristics.csv'
   FOLD_SAMPLE:
-    SEED: 4  # Seed for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
+    SEED: 0  # Seed for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     NUM_FOLDS: 5  # Number of desired external patient slices for augmenting training data during fine-tuning.
   FINETUNE:
     MODEL_DEF: 'efficientnet'  # Set this equal to the model definition string used for the pre-trained model.

--- a/config.yml
+++ b/config.yml
@@ -284,7 +284,7 @@ EXTERNAL_VAL:
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments'
   FOLD_SAMPLE:
-    SEED: 4  # Seed for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
+    SEED: 3  # Seed for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     NUM_FOLDS: 5  # Number of desired external patient slices for augmenting training data during fine-tuning.
   FINETUNE:
     MODEL_DEF: 'efficientnet'  # Set this equal to the model definition string used for the pre-trained model.

--- a/config.yml
+++ b/config.yml
@@ -270,7 +270,7 @@ EXPLAINABILITY:
 EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa', 'alberta']  # List of centers involved in the multi-center study.
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
-  NUM_TRIALS: 3  # Specify the number of fine-tuning trials.
+  NUM_TRIALS: 1  # Specify the number of fine-tuning trials.
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
@@ -295,8 +295,8 @@ EXTERNAL_VAL:
         SENSITIVITY: 90.1
         SPECIFICITY: 79.3
       UPPER_BOUNDS:
-    VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 10
+    VAL_SPLIT: 0.2 # Specify the train-val data split for each fine-tune run.
+    EPOCHS: 25
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.

--- a/config.yml
+++ b/config.yml
@@ -97,7 +97,7 @@ TRAIN:
       LR_DECAY_VAL: 0.05642  # Learning rate decay
       LR_DECAY_EPOCH: 15 # Epoch to start lr decay
       DROPOUT: 0.2151 # Dropout probability
-      LAYERS_FROZEN: 220 # Number of blocks to freeze - MUST be 0 or positive
+      LAYERS_FROZEN: 118 #161 # Number of blocks to freeze - MUST be 0 or positive
       L2_REG: 0.008629 # L2 regularization penalty
       WEIGHT_INITIALIZER: 'he_normal'  # Method to initialize weights for convolutional and FC layers - see https://www.tensorflow.org/api_docs/python/tf/keras/initializers
       ALPHA: 0.105 # focal loss parameter
@@ -284,7 +284,7 @@ EXTERNAL_VAL:
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments'
   FOLD_SAMPLE:
-    SEED: 3431  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
+    SEED: 4  # Seed for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     NUM_FOLDS: 5  # Number of desired external patient slices for augmenting training data during fine-tuning.
   FINETUNE:
     MODEL_DEF: 'efficientnet'  # Set this equal to the model definition string used for the pre-trained model.
@@ -300,7 +300,7 @@ EXTERNAL_VAL:
     PRED_PROBS:
       SAVE_PRED_PROBABILITIES: True # Set to True to save prediction labels for each clip when evaluating fine-tuned models.
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
-    LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
+    LR: 0.000171 #0.0000171  # For now, divide the original (efficientnet) lr by 10.
     MINORITY_FRAC: 0.25 # If minority upsampling, this is the desired fraction of the minority class in the training set
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.
   PLOT_METRICS: ['loss', 'sensitivity', 'specificity']  # Specify metrics for which to generate plots (for each trial and trial-wise average).

--- a/config.yml
+++ b/config.yml
@@ -33,8 +33,8 @@ PREPROCESS:
     MASKED_VIDEOS: '\generalizability\masked_videos\alberta'  # Path to the videos that result from running the masking tool on UNMASKED_VIDEOS.
     SMOOTHED_VIDEOS: '\results\data\smoothed_videos\'  # Path to the videos that result from applying a median filter to MASKED_VIDEOS (optional).
     FLOW_VIDEOS: 'flow_videos\'   # Path to the optical flow video frames (optional).
-    CSVS_OUTPUT: '\generalizability\csvs\alberta'  # Path to any CSVs that are generated / taken from the database.
-    NPZ: '\generalizability\npzs\alberta'  # Path to the mini-clip videos.
+    CSVS_OUTPUT: 'generalizability\csvs\alberta'  # Path to any CSVs that are generated / taken from the database.
+    NPZ: 'C:\Users\hsmle\Documents\Deep_Breathe\lung-sliding-classifier\generalizability\npzs\alberta'  # Path to the mini-clip videos.
     FLOW_NPZ: 'flow_npzs\'  # Path to the .npzs containing optical flow mini-clips.
     MASKING_TOOL: '\results\data\auto_masking_deeper.h5'  # Path to the masking tool. Currently only works with the older version!!!
 
@@ -270,7 +270,8 @@ EXPLAINABILITY:
 EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa', 'alberta']  # List of centers involved in the multi-center study.
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
-  NUM_TRIALS: 1  # Specify the number of fine-tuning trials.
+  NUM_TRIALS: 5  # Specify the number of fine-tuning trials.
+  MIN_TEST_SIZE: 0.5  # Specify the minimum proportion of external data to set aside for testing purposes.
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
@@ -282,6 +283,7 @@ EXTERNAL_VAL:
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments'
     TRIALS: '\generalizability\results\trials'
+    PLOTS: '\generalizability\results\experiments\plots'
   FOLD_SAMPLE:
     SEED: 42069  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     # There is one seed for each trial; insert or remove (or change) seeds as necessary/desired.
@@ -295,8 +297,9 @@ EXTERNAL_VAL:
         SENSITIVITY: 90.1
         SPECIFICITY: 79.3
       UPPER_BOUNDS:
-    VAL_SPLIT: 0.2 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 25
+    VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
+    EPOCHS: 50
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.
+  PLOT_METRICS: ['loss', 'sensitivity', 'specificity']  # Specify metrics for which to generate plots (for each trial and trial-wise average).

--- a/config.yml
+++ b/config.yml
@@ -284,7 +284,7 @@ EXTERNAL_VAL:
     FOLDS: '\generalizability\folds'  # Path to external data patient-wise fold .txt files.
     CSVS_SPLIT: '\generalizability\csvs_split'  # Path to train-test-val splits for external data.
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
-    EXPERIMENTS: '\generalizability\results\experiments\300922'
+    EXPERIMENTS: '\generalizability\results\experiments\031022'
     DATA_CHARACTERISTICS: 'data\generalizability\external_data_with_characteristics.csv'
   FOLD_SAMPLE:
     SEED: 0  # Seed for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
@@ -294,8 +294,8 @@ EXTERNAL_VAL:
     OVERWRITE_MODEL_DIR: True  # Set True if you want to clear existing contents in the model folder.
     METRIC_THRESHOLDS:  # Thresholds for assessing the performance of a fine-tuned model.
       LOWER_BOUNDS:
-        SENSITIVITY: 79.3
-        SPECIFICITY: 90.1
+        SENSITIVITY: 79.3 # Goal sensitivity for present lung sliding.
+        SPECIFICITY: 90.1 # Goal specificity (sensitivity for absent lung sliding).
       UPPER_BOUNDS:
     MIN_DELTA: 0.0001
     VAL_SPLIT: 0.2 # Specify the train-val data split for each fine-tune run.
@@ -307,11 +307,11 @@ EXTERNAL_VAL:
     MINORITY_FRAC: 0.25 # If minority upsampling, this is the desired fraction of the minority class in the training set
     LINEAR_FRAC: 0.25 # If upsampling linear probes, this is the desired fraction of linear probes in the training set
     SCHEME:
-      AB: False
-      UPSAMPLE: True
-      UPSAMPLE_LINEAR: False
-      FOCAL_LOSS: False
-      REINITIALIZE: False
-      CLASS_WEIGHT: True
+      AB: False # Set to True if you want to use the AB training scheme (finetune at full LR for 10 epochs, then LR/10)
+      UPSAMPLE: True # Set to True if you want to upsample from the minority class.
+      UPSAMPLE_LINEAR: False # Set to True if you want to upsample linear probe examples.
+      FOCAL_LOSS: False # Set to True if you want to use sigmoid focal cross entropy loss.
+      REINITIALIZE: False # Set to True if you want to randomly re-initialize the weights of the last 5 FC layers.
+      CLASS_WEIGHT: True # Set to True if you want to use the class_weight parameter in model.fit()
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.
   PLOT_METRICS: ['loss', 'sensitivity', 'specificity']  # Specify metrics for which to generate plots (for each trial and trial-wise average).

--- a/config.yml
+++ b/config.yml
@@ -97,7 +97,7 @@ TRAIN:
       LR_DECAY_VAL: 0.05642  # Learning rate decay
       LR_DECAY_EPOCH: 15 # Epoch to start lr decay
       DROPOUT: 0.2151 # Dropout probability
-      BLOCKS_FROZEN: 30 # Number of blocks to freeze - MUST be 0 or positive
+      BLOCKS_FROZEN: 161 # Number of blocks to freeze - MUST be 0 or positive
       L2_REG: 0.008629 # L2 regularization penalty
       WEIGHT_INITIALIZER: 'he_normal'  # Method to initialize weights for convolutional and FC layers - see https://www.tensorflow.org/api_docs/python/tf/keras/initializers
       ALPHA: 0.105 # focal loss parameter
@@ -275,6 +275,7 @@ EXTERNAL_VAL:
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
+    NPZS: '\generalizability\npzs'
     MMODES: '\generalizability\mmodes'  # Path to external data M-mode images.
     CSV_OUT: '\generalizability\csvs'  # Path to external data csvs.
     MODEL_OUT: '\generalizability\results\models'  # Path to fine-tuned models.
@@ -300,6 +301,8 @@ EXTERNAL_VAL:
     MIN_DELTA: 0.0001
     VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
     EPOCHS: 100
+    PRED_PROBS:
+      SAVE_PRED_PROBABILITIES: True # Set to True to save prediction labels for each clip when evaluating fine-tuned models.
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.

--- a/config.yml
+++ b/config.yml
@@ -270,7 +270,7 @@ EXPLAINABILITY:
 EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa', 'alberta']  # List of centers involved in the multi-center study.
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
-  NUM_TRIALS: 5  # Specify the number of fine-tuning trials.
+  NUM_TRIALS: 1  # Specify the number of fine-tuning trials.
   MIN_TEST_SIZE: 0.5  # Specify the minimum proportion of external data to set aside for testing purposes.
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.

--- a/config.yml
+++ b/config.yml
@@ -269,6 +269,7 @@ EXPLAINABILITY:
 
 EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa', 'alberta']  # List of centers involved in the multi-center study.
+  DATA_CHARACTERISTICS: ['clip_id','probe','location','patient_age','sex','depth_cat','manufacturer']
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
   NEW_EXPERIMENT: True   # If set to True, creates a new folder for trial artefacts.
   FIXED_TEST_SIZE: 0.4  # Specify the minimum proportion of external data to set aside for testing purposes.
@@ -283,6 +284,7 @@ EXTERNAL_VAL:
     CSVS_SPLIT: '\generalizability\csvs_split'  # Path to train-test-val splits for external data.
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments\300922'
+    DATA_CHARACTERISTICS: 'data/generalizability/external_data_with_characteristics.csv'
   FOLD_SAMPLE:
     SEED: 4  # Seed for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     NUM_FOLDS: 5  # Number of desired external patient slices for augmenting training data during fine-tuning.
@@ -303,5 +305,12 @@ EXTERNAL_VAL:
     LR: 0.000171 #0.0000171  # For now, divide the original (efficientnet) lr by 10.
     MINORITY_FRAC: 0.25 # If minority upsampling, this is the desired fraction of the minority class in the training set
     LINEAR_FRAC: 0.25 # If upsampling linear probes, this is the desired fraction of linear probes in the training set
+    SCHEME:
+      AB: False
+      UPSAMPLE: True
+      UPSAMPLE_LINEAR: False
+      FOCAL_LOSS: False
+      REINITIALIZE: False
+      CLASS_WEIGHT: True
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.
   PLOT_METRICS: ['loss', 'sensitivity', 'specificity']  # Specify metrics for which to generate plots (for each trial and trial-wise average).

--- a/config.yml
+++ b/config.yml
@@ -34,7 +34,7 @@ PREPROCESS:
     SMOOTHED_VIDEOS: '\results\data\smoothed_videos\'  # Path to the videos that result from applying a median filter to MASKED_VIDEOS (optional).
     FLOW_VIDEOS: 'flow_videos\'   # Path to the optical flow video frames (optional).
     CSVS_OUTPUT: 'generalizability\csvs\alberta'  # Path to any CSVs that are generated / taken from the database.
-    NPZ: 'C:\Users\hsmle\Documents\Deep_Breathe\lung-sliding-classifier\generalizability\npzs\alberta'  # Path to the mini-clip videos.
+    NPZ: 'generalizability\npzs\alberta'  # Path to the mini-clip videos.
     FLOW_NPZ: 'flow_npzs\'  # Path to the .npzs containing optical flow mini-clips.
     MASKING_TOOL: '\results\data\auto_masking_deeper.h5'  # Path to the masking tool. Currently only works with the older version!!!
 
@@ -297,8 +297,9 @@ EXTERNAL_VAL:
         SENSITIVITY: 90.1
         SPECIFICITY: 79.3
       UPPER_BOUNDS:
+    MIN_DELTA: 0.0001
     VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 100
+    EPOCHS: 1
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.

--- a/config.yml
+++ b/config.yml
@@ -276,7 +276,8 @@ EXTERNAL_VAL:
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
-    NPZS: '\src\data\generalizability\npzs'
+    NPZS: '\data\generalizability\npzs'
+    PNGS: '\data\generalizability\pngs'
     MMODES: '\generalizability\mmodes'  # Path to external data M-mode images.
     CSV_OUT: '\generalizability\csvs'  # Path to external data csvs.
     MODEL_OUT: '\generalizability\results\models'  # Path to fine-tuned models.

--- a/config.yml
+++ b/config.yml
@@ -297,7 +297,7 @@ EXTERNAL_VAL:
         SPECIFICITY: 79.3
       UPPER_BOUNDS:
     MIN_DELTA: 0.0001
-    VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
+    VAL_SPLIT: 0.2 # Specify the train-val data split for each fine-tune run.
     EPOCHS: 100
     PRED_PROBS:
       SAVE_PRED_PROBABILITIES: True # Set to True to save prediction labels for each clip when evaluating fine-tuned models.

--- a/config.yml
+++ b/config.yml
@@ -71,7 +71,7 @@ TRAIN:
   # Parameters for augmentation and model-training specifics.
   PARAMS:
     EPOCHS: 40  # Maximum number of epochs to train the model for.
-    BATCH_SIZE: 25  # Integer to set the batch size. If you're running into memory errors, you'll have to lower this. Set this to 1 for GRADCAM.
+    BATCH_SIZE: 10  # Integer to set the batch size. If you're running into memory errors, you'll have to lower this. Set this to 1 for GRADCAM.
     SHUFFLE: True  # Boolean, whether to shuffle the training set or not.
     INCREASE: False  # Boolean, whether to oversample the minority class (assumed to be the negative class) or not.
     AUGMENTATION_CHANCE: 0.8  # Probability to augment an incoming batch.
@@ -299,7 +299,7 @@ EXTERNAL_VAL:
       UPPER_BOUNDS:
     MIN_DELTA: 0.0001
     VAL_SPLIT: 0.1 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 1
+    EPOCHS: 100
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.0000171  # For now, divide the original (efficientnet) lr by 10.
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.

--- a/config.yml
+++ b/config.yml
@@ -29,13 +29,13 @@ PREPROCESS:
   # The paths to save files. After running the preprocess pipeline, the npzs and csvs are usually all that are needed to train.
   # You shouldn't *have* to edit these, as they are stored as relative and not absolute paths.
   PATHS:
-    UNMASKED_VIDEOS: '\generalizability\raw_videos/alberta'  # Path to the videos that are downloaded from the dataset and stored without transformation.
+    UNMASKED_VIDEOS: '\generalizability\raw_videos\alberta'  # Path to the videos that are downloaded from the dataset and stored without transformation.
     MASKED_VIDEOS: '\generalizability\masked_videos\alberta'  # Path to the videos that result from running the masking tool on UNMASKED_VIDEOS.
-    SMOOTHED_VIDEOS: '\results/data\smoothed_videos/'  # Path to the videos that result from applying a median filter to MASKED_VIDEOS (optional).
-    FLOW_VIDEOS: 'flow_videos/'   # Path to the optical flow video frames (optional).
+    SMOOTHED_VIDEOS: '\results\data\smoothed_videos\'  # Path to the videos that result from applying a median filter to MASKED_VIDEOS (optional).
+    FLOW_VIDEOS: 'flow_videos\'   # Path to the optical flow video frames (optional).
     CSVS_OUTPUT: '\generalizability\csvs\alberta'  # Path to any CSVs that are generated / taken from the database.
     NPZ: '\generalizability\npzs\alberta'  # Path to the mini-clip videos.
-    FLOW_NPZ: 'flow_npzs/'  # Path to the .npzs containing optical flow mini-clips.
+    FLOW_NPZ: 'flow_npzs\'  # Path to the .npzs containing optical flow mini-clips.
     MASKING_TOOL: '\results\data\auto_masking_deeper.h5'  # Path to the masking tool. Currently only works with the older version!!!
 
     # EXTRA refers to the first infusion of negative additions, which at the time of writing is kept separate
@@ -274,14 +274,14 @@ EXTERNAL_VAL:
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
-    MMODES: '/generalizability/mmodes'  # Path to external data M-mode images.
-    CSV_OUT: '/generalizability/csvs'  # Path to external data csvs.
-    MODEL_OUT: '/generalizability/results/models'  # Path to fine-tuned models.
-    FOLDS: '/generalizability/folds'  # Path to external data patient-wise fold .txt files.
-    CSVS_SPLIT: '/generalizability/csvs_split'  # Path to train-test-val splits for external data.
-    PREDICTIONS_OUT: '/generalizability/predictions'  # Path to predictions from fine-tuning experiments.
-    EXPERIMENTS: '/generalizability/results/experiments'
-    TRIALS: '/generalizability/results/trials'
+    MMODES: '\generalizability\mmodes'  # Path to external data M-mode images.
+    CSV_OUT: '\generalizability\csvs'  # Path to external data csvs.
+    MODEL_OUT: '\generalizability\results\models'  # Path to fine-tuned models.
+    FOLDS: '\generalizability\folds'  # Path to external data patient-wise fold .txt files.
+    CSVS_SPLIT: '\generalizability\csvs_split'  # Path to train-test-val splits for external data.
+    PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
+    EXPERIMENTS: '\generalizability\results\experiments'
+    TRIALS: '\generalizability\results\trials'
   FOLD_SAMPLE:
     SEED: 42069  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     # There is one seed for each trial; insert or remove (or change) seeds as necessary/desired.

--- a/config.yml
+++ b/config.yml
@@ -284,7 +284,7 @@ EXTERNAL_VAL:
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments'
   FOLD_SAMPLE:
-    SEED: 4  # Seed for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
+    SEED: 0  # Seed for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     NUM_FOLDS: 5  # Number of desired external patient slices for augmenting training data during fine-tuning.
   FINETUNE:
     MODEL_DEF: 'efficientnet'  # Set this equal to the model definition string used for the pre-trained model.

--- a/config.yml
+++ b/config.yml
@@ -29,12 +29,12 @@ PREPROCESS:
   # The paths to save files. After running the preprocess pipeline, the npzs and csvs are usually all that are needed to train.
   # You shouldn't *have* to edit these, as they are stored as relative and not absolute paths.
   PATHS:
-    UNMASKED_VIDEOS: '\generalizability\raw_videos\alberta'  # Path to the videos that are downloaded from the dataset and stored without transformation.
-    MASKED_VIDEOS: '\generalizability\masked_videos\alberta'  # Path to the videos that result from running the masking tool on UNMASKED_VIDEOS.
-    SMOOTHED_VIDEOS: '\results\data\smoothed_videos\'  # Path to the videos that result from applying a median filter to MASKED_VIDEOS (optional).
+    UNMASKED_VIDEOS: 'data\generalizability\raw_videos'  # Path to the videos that are downloaded from the dataset and stored without transformation.
+    MASKED_VIDEOS: 'data\generalizability\masked_videos\alberta'  # Path to the videos that result from running the masking tool on UNMASKED_VIDEOS.
+    SMOOTHED_VIDEOS: 'data\results\data\smoothed_videos\'  # Path to the videos that result from applying a median filter to MASKED_VIDEOS (optional).
     FLOW_VIDEOS: 'flow_videos\'   # Path to the optical flow video frames (optional).
     CSVS_OUTPUT: 'generalizability\csvs\alberta'  # Path to any CSVs that are generated / taken from the database.
-    NPZ: 'generalizability\npzs\alberta'  # Path to the mini-clip videos.
+    NPZ: 'data\generalizability\npzs\alberta'  # Path to the mini-clip videos.
     FLOW_NPZ: 'flow_npzs\'  # Path to the .npzs containing optical flow mini-clips.
     MASKING_TOOL: 'auto_masking_deeper.h5'  # Path to the masking tool. Currently only works with the older version!!!
 
@@ -97,7 +97,7 @@ TRAIN:
       LR_DECAY_VAL: 0.05642  # Learning rate decay
       LR_DECAY_EPOCH: 15 # Epoch to start lr decay
       DROPOUT: 0.2151 # Dropout probability
-      LAYERS_FROZEN: 161 #118 #161 # Number of blocks to freeze - MUST be 0 or positive
+      LAYERS_FROZEN: 220 #118 #161 # Number of blocks to freeze - MUST be 0 or positive
       L2_REG: 0.008629 # L2 regularization penalty
       WEIGHT_INITIALIZER: 'he_normal'  # Method to initialize weights for convolutional and FC layers - see https://www.tensorflow.org/api_docs/python/tf/keras/initializers
       ALPHA: 0.105 # focal loss parameter
@@ -275,16 +275,16 @@ EXTERNAL_VAL:
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
   PATHS:
-    NPZS: 'src\data\generalizability\npzs'
+    NPZS: '\src\data\generalizability\npzs'
     MMODES: '\generalizability\mmodes'  # Path to external data M-mode images.
     CSV_OUT: '\generalizability\csvs'  # Path to external data csvs.
     MODEL_OUT: '\generalizability\results\models'  # Path to fine-tuned models.
     FOLDS: '\generalizability\folds'  # Path to external data patient-wise fold .txt files.
     CSVS_SPLIT: '\generalizability\csvs_split'  # Path to train-test-val splits for external data.
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
-    EXPERIMENTS: '\generalizability\results\experiments'
+    EXPERIMENTS: '\generalizability\results\experiments\300922'
   FOLD_SAMPLE:
-    SEED: 0  # Seed for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
+    SEED: 4  # Seed for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     NUM_FOLDS: 5  # Number of desired external patient slices for augmenting training data during fine-tuning.
   FINETUNE:
     MODEL_DEF: 'efficientnet'  # Set this equal to the model definition string used for the pre-trained model.
@@ -296,11 +296,12 @@ EXTERNAL_VAL:
       UPPER_BOUNDS:
     MIN_DELTA: 0.0001
     VAL_SPLIT: 0.2 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 100
+    EPOCHS: 200
     PRED_PROBS:
       SAVE_PRED_PROBABILITIES: True # Set to True to save prediction labels for each clip when evaluating fine-tuned models.
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.
     LR: 0.000171 #0.0000171  # For now, divide the original (efficientnet) lr by 10.
     MINORITY_FRAC: 0.25 # If minority upsampling, this is the desired fraction of the minority class in the training set
+    LINEAR_FRAC: 0.25 # If upsampling linear probes, this is the desired fraction of linear probes in the training set
     # A value of False will run trials to completion, regardless of whether the model performance exceeds thresholds or not.
   PLOT_METRICS: ['loss', 'sensitivity', 'specificity']  # Specify metrics for which to generate plots (for each trial and trial-wise average).

--- a/config.yml
+++ b/config.yml
@@ -71,7 +71,7 @@ TRAIN:
   # Parameters for augmentation and model-training specifics.
   PARAMS:
     EPOCHS: 40  # Maximum number of epochs to train the model for.
-    BATCH_SIZE: 10  # Integer to set the batch size. If you're running into memory errors, you'll have to lower this. Set this to 1 for GRADCAM.
+    BATCH_SIZE: 40  # Integer to set the batch size. If you're running into memory errors, you'll have to lower this. Set this to 1 for GRADCAM.
     SHUFFLE: True  # Boolean, whether to shuffle the training set or not.
     INCREASE: False  # Boolean, whether to oversample the minority class (assumed to be the negative class) or not.
     AUGMENTATION_CHANCE: 0.8  # Probability to augment an incoming batch.
@@ -97,7 +97,7 @@ TRAIN:
       LR_DECAY_VAL: 0.05642  # Learning rate decay
       LR_DECAY_EPOCH: 15 # Epoch to start lr decay
       DROPOUT: 0.2151 # Dropout probability
-      BLOCKS_FROZEN: 161 # Number of blocks to freeze - MUST be 0 or positive
+      BLOCKS_FROZEN: 220 # Number of blocks to freeze - MUST be 0 or positive
       L2_REG: 0.008629 # L2 regularization penalty
       WEIGHT_INITIALIZER: 'he_normal'  # Method to initialize weights for convolutional and FC layers - see https://www.tensorflow.org/api_docs/python/tf/keras/initializers
       ALPHA: 0.105 # focal loss parameter
@@ -270,7 +270,7 @@ EXPLAINABILITY:
 EXTERNAL_VAL:
   LOCATIONS: ['chile', 'ottawa', 'alberta']  # List of centers involved in the multi-center study.
   REFRESH_FOLDERS: True  # If you want to delete contents of generalizability-related folders before writing, set True.
-  NUM_TRIALS: 1  # Specify the number of fine-tuning trials.
+  NUM_TRIALS: 5  # Specify the number of fine-tuning trials.
   MIN_TEST_SIZE: 0.5  # Specify the minimum proportion of external data to set aside for testing purposes.
   PARAMS:
     OVERWRITE_FOLDS: True  # Set this to True if you want to overwrite existing fold .txt files.
@@ -284,7 +284,7 @@ EXTERNAL_VAL:
     PREDICTIONS_OUT: '\generalizability\predictions'  # Path to predictions from fine-tuning experiments.
     EXPERIMENTS: '\generalizability\results\experiments'
   FOLD_SAMPLE:
-    SEED: 42069  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
+    SEED: 123  # Seed numbers for sampling external patient ids into slices, which are used during fine-tuning to augment training data as necessary.
     # There is one seed for each trial; insert or remove (or change) seeds as necessary/desired.
     OVERWRITE_FOLDER: True  # Set this to True if you want to overwrite existing fold .txt files.
     NUM_FOLDS: 5  # Number of desired external patient slices for augmenting training data during fine-tuning.
@@ -298,7 +298,7 @@ EXTERNAL_VAL:
       UPPER_BOUNDS:
     MIN_DELTA: 0.0001
     VAL_SPLIT: 0.2 # Specify the train-val data split for each fine-tune run.
-    EPOCHS: 100
+    EPOCHS: 1
     PRED_PROBS:
       SAVE_PRED_PROBABILITIES: True # Set to True to save prediction labels for each clip when evaluating fine-tuned models.
     LAZY: False # Set this to True if you want fine-tuning trials to terminate once model performance exceeds thresholds.

--- a/src/custom/layers.py
+++ b/src/custom/layers.py
@@ -1,0 +1,12 @@
+import tensorflow as tf
+
+class ToGrayscale(tf.keras.layers.Layer):
+    '''
+    Converts an RGB image input to a 3-channel grayscale image
+    '''
+
+    def __init__(self, name=None):
+        super(ToGrayscale, self).__init__(name=name)
+
+    def call(self, inputs):
+        return tf.image.grayscale_to_rgb(tf.image.rgb_to_grayscale(inputs))

--- a/src/data/download_videos.py
+++ b/src/data/download_videos.py
@@ -4,6 +4,7 @@ import os
 import urllib.request
 import yaml
 import cv2
+import tqdm
 from utils import refresh_folder
 from sql_utils import get_clips_from_db
 
@@ -61,7 +62,7 @@ def download(df, sliding, fr_rows, video_out_root_folder=cfg['PATHS']['UNMASKED_
     print('Writing ' + str(num_rows) + ' videos to ' + video_out_folder + '...')
 
     # Iterate through df to download the videos and preserve their id in the name
-    for index, row in df.iterrows():
+    for index, row in tqdm.tqdm(df.iterrows()):
         out_path = video_out_folder + row['id'] + '.mp4'
         row_no_whitespace = row['s3_path'].replace(' ', '%20')
         urllib.request.urlretrieve(row_no_whitespace, out_path)
@@ -76,20 +77,23 @@ def download(df, sliding, fr_rows, video_out_root_folder=cfg['PATHS']['UNMASKED_
 
 
 # Get database configs
-USERNAME = database_cfg['USERNAME']
-PASSWORD = database_cfg['PASSWORD']
-HOST = database_cfg['HOST']
-DATABASE = database_cfg['DATABASE']
+# USERNAME = database_cfg['USERNAME']
+# PASSWORD = database_cfg['PASSWORD']
+# HOST = database_cfg['HOST']
+# DATABASE = database_cfg['DATABASE']
+#
+# # Establish connection to database
+# cnx = mysql.connector.connect(user=USERNAME, password=PASSWORD,
+#                               host=HOST,
+#                               database=DATABASE)
+#
+# # Query Database for sliding and no_sliding labeled data but excluding significant probe movement and B lines
+# # and pleural effusion or consolidation
+# sliding_df = get_clips_from_db(cfg['PARAMS']['DB_TABLE'], sliding=True)
+# no_sliding_df = get_clips_from_db(cfg['PARAMS']['DB_TABLE'], sliding=-False)
 
-# Establish connection to database
-cnx = mysql.connector.connect(user=USERNAME, password=PASSWORD,
-                              host=HOST,
-                              database=DATABASE)
-
-# Query Database for sliding and no_sliding labeled data but excluding significant probe movement and B lines
-# and pleural effusion or consolidation
-sliding_df = get_clips_from_db(cfg['PARAMS']['DB_TABLE'], sliding=True)
-no_sliding_df = get_clips_from_db(cfg['PARAMS']['DB_TABLE'], sliding=-False)
+sliding_df = pd.read_csv('../../generalizability/csvs/ottawa/sliding.csv')
+no_sliding_df = pd.read_csv('../../generalizability/csvs/ottawa/no_sliding.csv')
 
 # sliding_df = pd.read_sql('''select * from clips_chile where view='parenchymal' and a_or_b_lines='a_lines'
 #                               and (quality NOT LIKE '%significant_probe_movement%' or quality is null)
@@ -99,11 +103,11 @@ no_sliding_df = get_clips_from_db(cfg['PARAMS']['DB_TABLE'], sliding=-False)
 #  and (pleural_line_findings = 'absent_lung_sliding');''', cnx)
 
 # Query database for extra negative examples from sprints
-no_sliding_extra_df = pd.read_sql('''SELECT * FROM clips_ottawa WHERE (pleural_line_findings='absent_lung_sliding'
-                                      OR pleural_line_findings='thickened|absent_lung_sliding') AND
-                               (quality NOT LIKE '%significant_probe_movement%' OR quality is null) AND
-                               (a_or_b_lines='a_lines' OR a_or_b_lines='non_a_non_b' OR a_or_b_lines is null) AND
-                               (pleural_effusion is null) AND (consolidation is null);''', cnx)
+# no_sliding_extra_df = pd.read_sql('''SELECT * FROM clips_ottawa WHERE (pleural_line_findings='absent_lung_sliding'
+#                                       OR pleural_line_findings='thickened|absent_lung_sliding') AND
+#                                (quality NOT LIKE '%significant_probe_movement%' OR quality is null) AND
+#                                (a_or_b_lines='a_lines' OR a_or_b_lines='non_a_non_b' OR a_or_b_lines is null) AND
+#                                (pleural_effusion is null) AND (consolidation is null);''', cnx)
 
 # load extra infusion of sliding clips
 # see code block from sliding_clip_infusion.py

--- a/src/data/download_videos.py
+++ b/src/data/download_videos.py
@@ -99,7 +99,7 @@ no_sliding_df = get_clips_from_db(cfg['PARAMS']['DB_TABLE'], sliding=-False)
 #  and (pleural_line_findings = 'absent_lung_sliding');''', cnx)
 
 # Query database for extra negative examples from sprints
-no_sliding_extra_df = pd.read_sql('''SELECT * FROM clips_chile WHERE (pleural_line_findings='absent_lung_sliding'
+no_sliding_extra_df = pd.read_sql('''SELECT * FROM clips_ottawa WHERE (pleural_line_findings='absent_lung_sliding'
                                       OR pleural_line_findings='thickened|absent_lung_sliding') AND
                                (quality NOT LIKE '%significant_probe_movement%' OR quality is null) AND
                                (a_or_b_lines='a_lines' OR a_or_b_lines='non_a_non_b' OR a_or_b_lines is null) AND

--- a/src/data/results/finetune_results_utils.py
+++ b/src/data/results/finetune_results_utils.py
@@ -125,18 +125,3 @@ def plot_finetune_results(results_csv):
 #
 # plot_finetune_results(res_df)
 
-if __name__ == '__main__':
-    import keras
-    experiments_dir = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
-    experiment_path = os.path.join(experiments_dir, os.listdir(experiments_dir)[-3])
-    exp_path_2 = os.path.join(experiments_dir, os.listdir(experiments_dir)[-8])
-    model = keras.models.load_model(os.path.join(experiment_path, 'trial_1', 'models', 'model_0.2_percent_train'), compile=False)
-    model_2 = keras.models.load_model(os.path.join(exp_path_2, 'trial_1', 'models', 'model_0.2_percent_train'), compile=False)
-    # count = 0
-    # for layer in model.layers:
-    #     print(layer.get_config())
-    #     if not layer.get_config()['trainable']:
-    #         count += 1
-    # print('Frozen layers:', count)
-    print(model.summary())
-    print(model_2.summary())

--- a/src/data/results/finetune_results_utils.py
+++ b/src/data/results/finetune_results_utils.py
@@ -2,94 +2,125 @@ import pandas as pd
 import os
 import yaml
 import matplotlib.pyplot as plt
-from src.data.sql_utils import add_date_to_filename
-from src.data.utils import refresh_folder
+import glob
+import numpy as np
+from shutil import rmtree
 
 cfg = yaml.full_load(open(os.path.join(os.getcwd(), "config.yml"), 'r'))['EXTERNAL_VAL']
 
 
-def finetune_results_to_csv(experiment_path=os.getcwd() + cfg['PATHS']['EXPERIMENTS']):
+def finetune_results_to_csv(experiment_path):
     '''
     Saves finetune results for each trial (and for each fold in that trial) as a csv file.
-    :param experiment_path: Full path to fine-tuning experiment files.
-    :return Str: Full path to the .csv file containing finetuning results across all trials.
+    :param experiment_path: Absolute path to fine-tuning experiment files.
+    :return Str: Absolute path to the .csv file containing finetuning results across all trials.
     '''
-    trial_results = []
-    for result_csv in os.listdir(experiment_path):
-        # The experiment folder also contains a subdirectory for plots. Skip over this to get to the actual result csvs.
-        if os.path.isdir(os.path.join(experiment_path, result_csv)):
-            continue
-        trial_results.append(pd.read_csv(os.path.join(experiment_path, result_csv)))
+    # trial_results is going to be the combined results .csv file.
+    trial_results = pd.DataFrame([])
+    trial_folders = glob.glob(os.path.join(experiment_path, 'trial_[0-9]*'))
 
-    trial_results = pd.concat(trial_results, ignore_index=True)
-    num_trials = cfg['NUM_TRIALS']
-    num_data_slices = len(os.listdir(experiment_path)) // num_trials
-    ext_data_props = [(n + 1) / num_trials for n in range(num_data_slices)] * num_trials
-    ext_data_props = pd.DataFrame(ext_data_props, columns=['ext_train_prop'])
-    trial_index = []
-    for t in range(num_trials):
-        trial_index.extend([t + 1] * num_data_slices)
-    trial_index = pd.DataFrame(trial_index, columns=['trial'])
-    trial_results = pd.concat([trial_index, ext_data_props, trial_results], axis=1)
-    print(trial_results)
-    # Adding '_df.csv' to the end of the resulting file name gets rid of permission error. Might want to investigate
-    # this further.
-    final_path = os.path.join(os.getcwd() + cfg['PATHS']['CSV_OUT'], add_date_to_filename('experiment_results') + '_df.csv')
+    # trial_numbers specifies which trial each result row is for in the .csv file.
+    trial_numbers = []
+    cur_trial_num = 1
+
+    # Combine results across all trials.
+    for trial in trial_folders:
+        metric_results_csv_path = glob.glob(os.path.join(trial, '*.csv'))[0]
+        metric_results_csv = pd.read_csv(metric_results_csv_path, index_col=0)
+        trial_numbers.extend([cur_trial_num] * len(metric_results_csv))
+        trial_results = pd.concat([trial_results, metric_results_csv])
+        cur_trial_num += 1
+
+    # Add trial_numbers as a column to the combined results df. Save as .csv file.
+    trial_numbers = pd.DataFrame(trial_numbers, columns=['trial']).reset_index(drop=True)
+    trial_results = trial_results.reset_index(drop=True)
+    trial_results = pd.concat([trial_numbers, trial_results], axis=1)
+    experiment_name = experiment_path.split('\\')[-1]
+    final_path = os.path.join(experiment_path, experiment_name + '_results.csv')
     trial_results.to_csv(final_path)
+
     return final_path
 
 
 def plot_finetune_results(results_csv):
     '''
-    Plots finetuning results for metrics specified in the config file (currently loss/sensitivity/specificity). Plots
-    results by individual trial along with trial-wise averages for each metric.
-    :param results_csv: Full path to .csv file containing fine-tuning results
+    Plots fine-tuning results for metrics specified in the config file (currently loss/sensitivity/specificity).
+    Generates a plot for each metric in results_csv by trial, along with trial-wise averages for each metric.
+    :param results_csv: Absolute path to .csv file containing fine-tuning results.
     '''
     results_df = pd.read_csv(results_csv)
-    num_trials = cfg['NUM_TRIALS']
-    num_data_slices = len(results_df) // num_trials
-    # Set up the x-axis for plotting.
-    x = list(results_df['ext_train_prop'])[:num_data_slices]
-    plot_metrics = cfg['PLOT_METRICS']
-    path_to_plots = os.getcwd() + cfg['PATHS']['PLOTS']
-    if cfg['REFRESH_FOLDERS']:
-        refresh_folder(path_to_plots)
-    # Extract metric values from result df. Generate plots and save them.
-    plt_ind = 0
-    for metric in plot_metrics:
-        metric_values = results_df[metric].values
-        y = []
-        for i in range(0, len(metric_values), num_data_slices):
-            y.append(metric_values[i:i + num_data_slices])
-        plt.figure(plt_ind)
-        for trial_y in y:
-            plt.plot(x, trial_y)
-        # Compute trial-wise average metric value
-        trial_avgs = []
-        for i in range(num_data_slices):
-            total = 0
-            for j in range(num_trials):
-                total += metric_values[i + j * num_data_slices]
-            avg = total / num_trials
-            trial_avgs.append(avg)
-        plt.plot(x, trial_avgs, linestyle='dashed')
-        plt.xticks(x)
-        plt.xlabel('External Training Data Proportion')
-        # Sensitivity and specificity metric values need to be flipped to follow convention with original lung sliding
-        # manuscript.
-        if metric == 'sensitivity':
-            metric = 'specificity'
-        elif metric == 'specificity':
-            metric = 'sensitivity'
-        # Capitalize the name of the metric
-        y_axis_label = metric[0].upper() + metric[1:]
-        plt.ylabel(y_axis_label)
-        plt.title(y_axis_label + ' vs Proportion of External Data as Train Set')
-        legend_strs = []
-        for i in range(num_trials):
-            legend_strs.append('Trial ' + str(i + 1))
-        legend_strs.append('Average ' + y_axis_label + ' (Trial-Wise)')
-        plt.legend(legend_strs)
-        plt.savefig(os.path.join(path_to_plots, add_date_to_filename(metric) + '.jpg'))
-        plt_ind += 1
 
+    # The absolute path to the corresponding experiment is the parent directory for the results .csv file.
+    experiment_path = '\\'.join(results_csv.split('\\')[:-1])
+
+    # Make a folder to store the plots.
+    plot_dir = os.path.join(experiment_path, 'plots')
+
+    # If there are already plots in the experiment folder, overwrite with new plots.
+    if os.path.exists(plot_dir):
+        rmtree(plot_dir)
+
+    os.makedirs(plot_dir)
+
+    # Get list of external data proportions used for training in the experiment.
+    first_trial_results = results_df[results_df['trial'] == 1]
+    ext_data_props = first_trial_results[first_trial_results['variable_sized_test_set'] == 1]['ext_data_prop'].values
+
+    metrics = cfg['PLOT_METRICS']
+    num_trials = cfg['NUM_TRIALS']
+    plot_ind = 0
+    legend_labels = []
+
+    for metric in metrics:
+        # New figure.
+        plt.figure(plot_ind)
+        plt.xlabel('Proportion of External Data Used for Train')
+        metric_name = metric[0].upper() + metric[1:]
+        plt.ylabel(metric_name)
+        plt.title(metric_name + ' vs External Train Proportion')
+
+        for test_set_type in [1, 0]:
+            style = 'solid'
+            if test_set_type == 0:
+                style = 'dashed'
+            results_for_test_set_type = results_df[results_df['variable_sized_test_set'] == test_set_type]
+            test_set_size_label = '({} Test Set Size)'.format('Variable' if test_set_type == 1 else 'Fixed')
+
+            # Plot results for each trial.
+            for t in range(num_trials):
+                results_to_plot = results_for_test_set_type[results_for_test_set_type['trial'] == t + 1]
+
+                # Plot results for each of variable and fixed test set sizes.
+                trial_metric_vals = results_to_plot[metric].values
+                plt.plot(ext_data_props, trial_metric_vals, linestyle=style)
+
+                legend_labels.append('Trial {} {}'.format(t + 1, test_set_size_label))
+
+            # Plot average metric value across trials.
+            trial_avgs = []
+            for prop in ext_data_props:
+                avg_for_prop = np.mean(results_for_test_set_type[results_for_test_set_type['variable_sized_test_set'] ==
+                                                                 test_set_type][metric])
+                trial_avgs.append(avg_for_prop)
+
+            # Trial-wise averages are denoted with bold lines.
+            plt.plot(ext_data_props, trial_avgs, linestyle=style, linewidth=3)
+
+            legend_labels.append('Trial-Wise Average {}'.format(test_set_size_label))
+
+        # Add a legend
+        plt.legend(legend_labels, bbox_to_anchor=(1, 2))
+
+        experiment_name = experiment_path.split('\\')[-1]
+        plt.savefig(os.path.join(plot_dir, experiment_name + '_' + metric + '.png'))
+
+        # Update plot figure counter.
+        plot_ind += 1
+        legend_labels = []
+
+
+experiment_path = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
+experiment_path = os.path.join(experiment_path, os.listdir(experiment_path)[-1])
+res_df = finetune_results_to_csv(experiment_path)
+
+plot_finetune_results(res_df)

--- a/src/data/results/finetune_results_utils.py
+++ b/src/data/results/finetune_results_utils.py
@@ -124,3 +124,19 @@ def plot_finetune_results(results_csv):
 # res_df = finetune_results_to_csv(experiment_path)
 #
 # plot_finetune_results(res_df)
+
+if __name__ == '__main__':
+    import keras
+    experiments_dir = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
+    experiment_path = os.path.join(experiments_dir, os.listdir(experiments_dir)[-3])
+    exp_path_2 = os.path.join(experiments_dir, os.listdir(experiments_dir)[-8])
+    model = keras.models.load_model(os.path.join(experiment_path, 'trial_1', 'models', 'model_0.2_percent_train'), compile=False)
+    model_2 = keras.models.load_model(os.path.join(exp_path_2, 'trial_1', 'models', 'model_0.2_percent_train'), compile=False)
+    # count = 0
+    # for layer in model.layers:
+    #     print(layer.get_config())
+    #     if not layer.get_config()['trainable']:
+    #         count += 1
+    # print('Frozen layers:', count)
+    print(model.summary())
+    print(model_2.summary())

--- a/src/data/results/finetune_results_utils.py
+++ b/src/data/results/finetune_results_utils.py
@@ -5,14 +5,16 @@ import matplotlib.pyplot as plt
 import glob
 import numpy as np
 from shutil import rmtree
+import seaborn as sns
 
 cfg = yaml.full_load(open(os.path.join(os.getcwd(), "config.yml"), 'r'))['EXTERNAL_VAL']
 
 
-def finetune_results_to_csv(experiment_path):
+def finetune_results_to_csv(experiment_path, group=None):
     '''
     Saves finetune results for each trial (and for each fold in that trial) as a csv file.
     :param experiment_path: Absolute path to fine-tuning experiment files.
+    :param group: If not None, specifies the subgroup whose results we'd like to summarize.
     :return Str: Absolute path to the .csv file containing finetuning results across all trials.
     '''
     # trial_results is going to be the combined results .csv file.
@@ -25,7 +27,10 @@ def finetune_results_to_csv(experiment_path):
 
     # Combine results across all trials.
     for trial in trial_folders:
-        metric_results_csv_path = glob.glob(os.path.join(trial, '*.csv'))[1]
+        if group is not None:
+            metric_results_csv_path = glob.glob(os.path.join(trial, 'metrics_by_{}.csv'.format(group)))[0]
+        else:
+            metric_results_csv_path = glob.glob(os.path.join(trial, 'metrics.csv'))[0]
         metric_results_csv = pd.read_csv(metric_results_csv_path)
         trial_numbers.extend([cur_trial_num] * len(metric_results_csv))
         trial_results = pd.concat([trial_results, metric_results_csv])
@@ -36,98 +41,470 @@ def finetune_results_to_csv(experiment_path):
     trial_results = trial_results.reset_index(drop=True)
     trial_results = pd.concat([trial_numbers, trial_results], axis=1)
     experiment_name = experiment_path.split('\\')[-1]
-    final_path = os.path.join(experiment_path, experiment_name + '_results.csv')
+    if group is not None:
+        final_path = os.path.join(experiment_path, experiment_name + '_results_by_{}.csv'.format(group))
+    else:
+        final_path = os.path.join(experiment_path, experiment_name + '_results.csv')
     trial_results.to_csv(final_path)
 
     return final_path
 
 
-def plot_finetune_results(results_csv):
+def plot_finetune_results(experiment_path, flip_labels=True, summarize=True, titles=None, plot_threshold=True):
     '''
     Plots fine-tuning results for metrics specified in the config file (currently loss/sensitivity/specificity).
     Generates a plot for each metric in results_csv by trial, along with trial-wise averages for each metric.
-    :param results_csv: Absolute path to .csv file containing fine-tuning results.
+    :param experiment_path: Absolute path to the directory of the experiment whose results you'd like to plot
+    :param flip_labels: Whether to flip the positive/negative class labels. If True, absent (present) lung sliding will
+    be considered the positive (negative) class. If False, absent (present) lung sliding will be considered the negative
+    (positive) class (as observed during training).
+    :param summarize: If True, all metrics are plotted on one figure as individual subplots.
+    :param titles: If not None, list of titles to give (sub)plot(s).
+    :param plot_threshold: If True, the desired 'goal' metric is plotted as a horizontal line.
     '''
-    results_df = pd.read_csv(results_csv)
-    num_trials = len(glob.glob(os.path.split(results_csv)[0] + '/trial_*'))
+    results_csv = os.path.join(exp_path, os.path.basename(exp_path)+'_results.csv')
+    if not os.path.exists(results_csv):
+        results_csv = finetune_results_to_csv(experiment_path)
 
-    # The absolute path to the corresponding experiment is the parent directory for the results .csv file.
-    experiment_path = '\\'.join(results_csv.split('\\')[:-1])
+    results_df = pd.read_csv(results_csv)
+
+    if flip_labels:
+        results_df.rename(columns={'sensitivity':'specificity_temp','specificity':'sensitivity'},inplace=True)
+        results_df.rename(columns={'specificity_temp':'specificity'}, inplace=True)
 
     # Make a folder to store the plots.
     plot_dir = os.path.join(experiment_path, 'plots')
 
-    # If there are already plots in the experiment folder, overwrite with new plots.
-    if os.path.exists(plot_dir):
-        rmtree(plot_dir)
-
-    os.makedirs(plot_dir)
+    # If the plotting directory doesn't exist, make one
+    if not os.path.exists(plot_dir):
+        os.makedirs(plot_dir)
 
     # Get list of external data proportions used for training in the experiment.
     first_trial_results = results_df[results_df['trial'] == 1]
     ext_data_props = first_trial_results[first_trial_results['variable_size_test_set'] == 1]['train_data_prop'].values
 
     metrics = cfg['PLOT_METRICS']
+    num_trials = results_df['trial'].max()
     plot_ind = 0
     legend_labels = []
 
+    fig_name = os.path.basename(experiment_path)
+
+    if summarize:
+        fig, axs = plt.subplots(1, len(metrics), figsize=(5 + 5*len(metrics),5))
+
     for metric in metrics:
-        # New figure.
-        plt.figure(plot_ind)
-        plt.xlabel('Proportion of External Data Used for Train')
+        if not summarize:
+            fig, ax = plt.subplots(1, 1, figsize=(10,5))
+        else:
+            ax = axs[plot_ind]
+
+        if metric == 'sensitivity':
+            thresh = 0.793
+            ylimits = [0.3, 1.01]
+        elif metric == 'specificity':
+            thresh = 0.901
+            ylimits = [0.3, 1.01]
+        else:
+            thresh = None
+            ylimits = [0, 0.7]
+
+        ax.set_xlabel('Proportion of External Data Used for Training', fontsize=12)
         metric_name = metric[0].upper() + metric[1:]
-        plt.ylabel(metric_name)
-        plt.title(metric_name + ' vs External Train Proportion')
+        ax.set_ylabel(metric_name, fontsize=12)
+        ax.set_xticks(ext_data_props, fontsize=12)
+        ax.set_ylim(ylimits)
+        if titles is not None:
+            ax.set_title(titles[plot_ind])
+
+        for test_set_type in [1, 0]:
+            style = 'solid'
+            marker = '*'
+            if test_set_type == 0:
+                style = 'dashed'
+            results_for_test_set_type = results_df[results_df['variable_size_test_set'] == test_set_type]
+            test_set_size_label = '({} Test Set)'.format('Variable' if test_set_type == 1 else 'Fixed')
+
+            # Plot results for each trial.
+            colours = plt.cm.plasma(np.linspace(0, 0.9, num_trials))
+            for t in range(num_trials):
+                results_to_plot = results_for_test_set_type[results_for_test_set_type['trial'] == t + 1]
+
+                # Plot results for each of variable and fixed test set sizes.
+                trial_metric_vals = results_to_plot[metric].values
+                ax.plot(ext_data_props, trial_metric_vals, linestyle=style,color=colours[t],marker=marker,linewidth=1,markersize=6)
+
+                legend_labels.append('Trial {} {}'.format(t + 1, test_set_size_label))
+
+            # Plot average metric value across trials.
+            trial_avgs = []
+            trial_stds = []
+            for prop in ext_data_props:
+                avg_for_prop = np.mean(results_for_test_set_type[results_for_test_set_type['train_data_prop'] ==
+                                                                 prop][metric])
+                std_for_prop = np.std(results_for_test_set_type[results_for_test_set_type['train_data_prop'] ==
+                                                                prop][metric])
+                trial_avgs.append(avg_for_prop)
+                trial_stds.append(std_for_prop)
+
+            # Trial-wise averages are denoted in black
+            ax.plot(ext_data_props, trial_avgs, linestyle=style, linewidth=2.5, color='k', zorder=100)
+
+            legend_labels.append('Trial-Wise Mean {}'.format(test_set_size_label))
+
+        # Add a legend
+        if not summarize or plot_ind == len(metrics) - 1:
+            ax.legend(legend_labels, fontsize=12, bbox_to_anchor=(1.05, 0.9))
+
+        if plot_threshold and thresh is not None:
+            ax.axhline(y=thresh)
+
+        fig_name += '_' + metric
+
+        if summarize:
+            plt.subplots_adjust(left=0.1,
+                                bottom=0.1,
+                                right=0.9,
+                                top=0.9,
+                                wspace=0.2,
+                                hspace=0.2)
+            plt.tight_layout()
+        else:
+            plt.tight_layout()
+            plt.savefig(os.path.join(plot_dir, fig_name + '.png'))
+            fig_name = os.path.basename(experiment_path)
+
+        # Update plot figure counter.
+        plot_ind += 1
+        legend_labels = []
+
+    if summarize:
+        plt.savefig(os.path.join(plot_dir, fig_name + '.png'))
+
+        return fig
+
+
+def plot_subgroup_analysis_results(experiment_path, flip_labels=True, group='center', plot_threshold=True):
+    '''
+    Plots fine-tuning results for metrics specified in the config file (currently loss/sensitivity/specificity).
+    Generates a plot for each metric in results_csv by trial, along with trial-wise averages for each metric.
+    :param experiment_path: Absolute path to the directory of the experiment whose results you'd like to plot
+    :param flip_labels: Whether to flip the positive/negative class labels. If True, absent (present) lung sliding will
+    be considered the positive (negative) class. If False, absent (present) lung sliding will be considered the negative
+    (positive) class (as observed during training).
+    :param group (str): Specifies which subgroup we're interested in plotting
+    :param plot_threshold: If True, the desired 'goal' metric is plotted as a horizontal line.
+    '''
+    results_csv = os.path.join(exp_path, os.path.basename(exp_path)+'_results_by_{}.csv'.format(group))
+    if not os.path.exists(results_csv):
+        results_csv = finetune_results_to_csv(experiment_path, group=group)
+
+    results_df = pd.read_csv(results_csv)
+
+    # If true, sets absent lung sliding as the positive class
+    if flip_labels:
+        results_df.rename(columns={'sensitivity': 'specificity_temp', 'specificity': 'sensitivity'}, inplace=True)
+        results_df.rename(columns={'specificity_temp': 'specificity'}, inplace=True)
+
+    # Designate plotting directory
+    plot_dir = os.path.join(experiment_path, 'plots')
+
+    # If the plotting directory doesn't exist, make one
+    if not os.path.exists(plot_dir):
+        os.makedirs(plot_dir)
+
+    metrics = cfg['PLOT_METRICS']
+    num_trials = results_df['trial'].max()
+
+    # Get list of external data proportions used for training in the experiment.
+    first_trial_results = results_df[results_df['trial'] == 1]
+    ext_data_props = first_trial_results[first_trial_results['variable_size_test_set'] == 1]['train_data_prop'].unique()
+
+    fig_name = os.path.basename(experiment_path)
+
+    fig, axs = plt.subplots(len(results_df[group].unique()),
+                            len(metrics),
+                            figsize=(5 + 5 * len(metrics),
+                                     5 + 5*len(results_df[group].unique())))
+    subgroup_ind = 0
+
+    for subgroup in results_df[group].unique():
+        df = results_df.loc[results_df[group] == subgroup]
+
+        legend_labels = []
+        metric_ind = 0
+        for metric in metrics:
+            ax = axs[subgroup_ind][metric_ind]
+
+            if metric == 'sensitivity':
+                thresh = 0.793
+                ylimits = [0, 1.01]
+            elif metric == 'specificity':
+                thresh = 0.901
+                ylimits = [0, 1.01]
+            else:
+                thresh = None
+                ylimits = [0, 0.3]
+
+            ax.set_xlabel('Proportion of External Data Used for Training', fontsize=16)
+            metric_name = metric[0].upper() + metric[1:]
+            ax.set_ylabel(metric_name, fontsize=16)
+            ax.set_xticks(ext_data_props, fontsize=16)
+            ax.set_ylim(ylimits)
+
+            ax.set_title('{}: {}'.format(group,subgroup), fontsize=16)
+            if plot_threshold and thresh is not None:
+                ax.axhline(y=thresh, color='k')
+
+            for test_set_type in [1, 0]:
+                style = 'solid'
+                marker = '*'
+                if test_set_type == 0:
+                    style = 'dashed'
+                results_for_test_set_type = df[df['variable_size_test_set'] == test_set_type]
+                test_set_size_label = '({} Test Set)'.format('Variable' if test_set_type == 1 else 'Fixed')
+
+                # Plot results for each trial.
+                colours = plt.cm.plasma(np.linspace(0, 0.9, num_trials))
+                for t in range(num_trials):
+                    results_to_plot = results_for_test_set_type[results_for_test_set_type['trial'] == t + 1]
+
+                    # Plot results for each of variable and fixed test set sizes.
+                    trial_metric_vals = results_to_plot[metric].values
+                    ax.plot(ext_data_props, trial_metric_vals, linestyle=style, color=colours[t], marker=marker,
+                            linewidth=1, markersize=6)
+
+                    legend_labels.append('Trial {} {}'.format(t + 1, test_set_size_label))
+
+                # Plot average metric value across trials.
+                trial_avgs = []
+                trial_stds = []
+                for prop in ext_data_props:
+                    avg_for_prop = np.mean(results_for_test_set_type[results_for_test_set_type['train_data_prop'] ==
+                                                                     prop][metric])
+                    std_for_prop = np.std(results_for_test_set_type[results_for_test_set_type['train_data_prop'] ==
+                                                                    prop][metric])
+                    trial_avgs.append(avg_for_prop)
+                    trial_stds.append(std_for_prop)
+
+                # Trial-wise averages are denoted in black
+                ax.plot(ext_data_props, trial_avgs, linestyle=style, linewidth=2.5, color='k', zorder=100)
+
+                legend_labels.append('Trial-Wise Mean {}'.format(test_set_size_label))
+
+            # Update plot figure counter.
+            metric_ind += 1
+            legend_labels = []
+        subgroup_ind += 1
+
+    plt.tight_layout()
+
+    plt.savefig(os.path.join(plot_dir, fig_name + '_results_by_{}.png'.format(group)))
+
+
+def plot_mean_sensitivity_specificity_tradeoff(experiment_path, flip_labels=True,get_intersection_of=None,print_metrics=False):
+
+    '''
+    Plots fine-tuning results for metrics specified in the config file (currently loss/sensitivity/specificity).
+    Generates a plot for each metric in results_csv by trial, along with trial-wise averages for each metric.
+    :param experiment_path: Absolute path to the directory of the experiment whose results you'd like to plot
+    :param flip_labels: Whether to flip the positive/negative class labels. If True, absent (present) lung sliding will
+    be considered the positive (negative) class. If False, absent (present) lung sliding will be considered the negative
+    (positive) class (as observed during training).
+    :param get_intersection_of: If not None, specifies the test set ('fixed' or 'variable') on which to evaluate and
+    plot intersection of specificity and sensitivity in terms of the external data proportion.
+    :param print_metrics: If True, prints average metrics.
+    '''
+
+    results_csv = os.path.join(exp_path, os.path.basename(exp_path) + '_results.csv')
+    if not os.path.exists(results_csv):
+        results_csv = finetune_results_to_csv(experiment_path)
+
+    results_df = pd.read_csv(results_csv)
+
+    if flip_labels:
+        results_df.rename(columns={'sensitivity':'specificity_temp','specificity':'sensitivity'},inplace=True)
+        results_df.rename(columns={'specificity_temp':'specificity'}, inplace=True)
+
+    # Make a folder to store the plots.
+    plot_dir = os.path.join(experiment_path, 'plots')
+
+    # If the plotting directory doesn't exist, make one
+    if not os.path.exists(plot_dir):
+        os.makedirs(plot_dir)
+
+    # Get list of external data proportions used for training in the experiment.
+    first_trial_results = results_df[results_df['trial'] == 1]
+    ext_data_props = first_trial_results[first_trial_results['variable_size_test_set'] == 1]['train_data_prop'].values
+
+    metrics = ['sensitivity', 'specificity']
+    legend_labels = []
+
+    fig_name = os.path.basename(experiment_path) + '_compare_mean'
+
+    fig, ax = plt.subplots(1, 1, figsize=(8,5))
+
+    ax.set_xlabel('Proportion of External Data Used for Training', fontsize=12)
+    ax.set_ylabel('Metric', fontsize=12)
+    ax.set_xticks(ext_data_props, fontsize=12)
+
+    avg_specificity_variable = []
+    avg_specificity_fixed = []
+    avg_sensitivity_variable = []
+    avg_sensitivity_fixed = []
+
+    for metric in metrics:
+
+        metric_name = metric[0].upper() + metric[1:]
+        if metric_name == 'Specificity':
+            colour = 'r'
+        else:
+            colour = 'tab:blue'
 
         for test_set_type in [1, 0]:
             style = 'solid'
             if test_set_type == 0:
                 style = 'dashed'
             results_for_test_set_type = results_df[results_df['variable_size_test_set'] == test_set_type]
-            test_set_size_label = '({} Test Set Size)'.format('Variable' if test_set_type == 1 else 'Fixed')
-
-            # Plot results for each trial.
-            for t in range(num_trials):
-                results_to_plot = results_for_test_set_type[results_for_test_set_type['trial'] == t + 1]
-
-                # Plot results for each of variable and fixed test set sizes.
-                trial_metric_vals = results_to_plot[metric].values
-                plt.plot(ext_data_props, trial_metric_vals, linestyle=style)
-
-                legend_labels.append('Trial {} {}'.format(t + 1, test_set_size_label))
+            test_set_size_label = '({} Test Set)'.format('Variable' if test_set_type == 1 else 'Fixed')
 
             # Plot average metric value across trials.
             trial_avgs = []
+            trial_stds = []
             for prop in ext_data_props:
-                avg_for_prop = np.mean(results_for_test_set_type[results_for_test_set_type['variable_size_test_set'] ==
-                                                                 test_set_type][metric])
+                avg_for_prop = np.mean(results_for_test_set_type[results_for_test_set_type['train_data_prop'] ==
+                                                                 prop][metric])
+                std_for_prop = np.std(results_for_test_set_type[results_for_test_set_type['train_data_prop'] ==
+                                                                prop][metric])
                 trial_avgs.append(avg_for_prop)
+                trial_stds.append(std_for_prop)
+            if test_set_type == 1:
+                if metric_name == 'Specificity':
+                    avg_specificity_variable = trial_avgs
+                elif metric_name == 'Sensitivity':
+                    avg_sensitivity_variable = trial_avgs
+            else:
+                if metric_name == 'Specificity':
+                    avg_specificity_fixed = trial_avgs
+                elif metric_name == 'Sensitivity':
+                    avg_sensitivity_fixed = trial_avgs
 
-            # Trial-wise averages are denoted with bold lines.
-            plt.plot(ext_data_props, trial_avgs, linestyle=style, linewidth=3)
+            # Trial-wise averages are denoted in black
+            ax.plot(ext_data_props, trial_avgs, linestyle=style, linewidth=2, color=colour, zorder=100)
+            legend_labels.append('Mean Trial-Wise {} {}'.format(metric_name,test_set_size_label))
 
-            legend_labels.append('Trial-Wise Average {}'.format(test_set_size_label))
+            if not (metric in fig_name):
+                fig_name += '_' + metric
 
-        # Add a legend
-        plt.legend(legend_labels, bbox_to_anchor=(1, 2))
+    if print_metrics:
+        print('Mean sensitivity:')
+        print('External data training proportion: {}'.format(list(ext_data_props)))
+        print('Variable test set: {}'.format(avg_sensitivity_variable))
+        print('Fixed test set: {}'.format(avg_sensitivity_fixed))
+        print('\nMean specificity:')
+        print('External data training proportion: {}'.format(list(ext_data_props)))
+        print('Variable test set: {}'.format(avg_specificity_variable))
+        print('Fixed test set: {}'.format(avg_specificity_fixed))
 
-        experiment_name = experiment_path.split('\\')[-1]
-        plt.savefig(os.path.join(plot_dir, experiment_name + '_' + metric + '.png'))
+    # Add a legend
+    ax.legend(legend_labels, fontsize=12, loc='best')
 
-        # Update plot figure counter.
-        plot_ind += 1
-        legend_labels = []
+    if get_intersection_of is not None:
 
-#
-experiment_path = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
-experiment_path = os.path.join(experiment_path, os.listdir(experiment_path)[-1])
-res_df = finetune_results_to_csv(experiment_path)
+        if get_intersection_of == 'variable':
+            x_itn, sens_itn, spec_itn = get_intersection_point(ext_data_props,
+                                                               avg_sensitivity_variable,
+                                                               avg_specificity_variable)
+        elif get_intersection_of == 'fixed':
+            x_itn, sens_itn, spec_itn = get_intersection_point(ext_data_props,
+                                                               avg_sensitivity_fixed,
+                                                               avg_specificity_fixed)
 
-plot_finetune_results(res_df)
+        ax.vlines(x_itn, 0.5, sens_itn, linestyle=":", linewidth=1.5, color='#424242')
+        ax.vlines(x_itn, 0.5, spec_itn, linestyle=":", linewidth=1.5, color='#424242')
+        ax.hlines(sens_itn, 0, x_itn, linestyle=":", linewidth=1.5, color='tab:blue')
+        ax.plot(x_itn, sens_itn,linestyle=':',marker='o', color='tab:blue', markersize=9)
+        ax.hlines(spec_itn, 0, x_itn, linestyle=":", linewidth=1.5, color='tab:red')
+        ax.plot(x_itn, spec_itn, 'ro', markersize=9,zorder=200)
+        ax.text(x_itn, sens_itn +0.025, "Training proportion = {}".format(x_itn),
+            ha='right', va='center', fontsize=10, color='#424242')
+        ax.text(x_itn, sens_itn +0.05, "Sensitivity = {:.3f}".format(sens_itn),
+            ha='right', va='center', fontsize=10, color="tab:blue")
+        ax.text(x_itn, sens_itn +0.075, "Specificity = {:.3f}".format(spec_itn),
+            ha='right', va='center', fontsize=10, color="tab:red")
 
-# if __name__ == '__main__':
-#     exp_dir = os.path.join(os.getcwd() + cfg['PATHS']['EXPERIMENTS'])
-#     exp_path = glob.glob(os.path.join(exp_dir, 'experiment_1660921548.0\\trial_1\\upsample_miniclips.csv'))[0]
-#     upsample_csv = pd.read_csv(exp_path)
-#     print(len(upsample_csv))
-#     print(upsample_csv.loc[upsample_csv.duplicated(subset=['miniclip_id'])])
+        plt.savefig(os.path.join(plot_dir, fig_name + '_' + get_intersection_of + '.png'))
+    else:
+        plt.savefig(os.path.join(plot_dir, fig_name + '_.png'))
+
+    return fig
+
+
+def get_intersection_point(x, y_sens, y_spec):
+    '''
+    Computes the intersection of sensitivity and specificity vectors.
+    :param x: vector of external data proportions, corresponding to the sensitivity and specificity vectors.
+    :param y_sens: sensitivity vector corresponding to the external data proportions specified by x.
+    :param y_spec: specificity vector corresponding to the external data proportions specified by x.
+    '''
+
+    x_itn, sens_itn = 0, 0
+    min_diff = 100.
+    for i in range(x.shape[0]):
+        abs_diff = np.abs(y_sens[i] - y_spec[i])
+        if abs_diff < min_diff:
+            min_diff = abs_diff
+            x_itn = x[i]
+            sens_itn = y_sens[i]
+            spec_itn = y_spec[i]
+    return x_itn, sens_itn, spec_itn
+
+
+def export_mmode_to_png(npz,npz_dir,save_dir):
+    '''
+    Loads an mmode from an npz file and saves it as a png.
+    :param npz: file name of the npz (with file extension)
+    :param npz_dir: directory where the npz is stored
+    :param save_dir: directory where you'd like the png saved
+    '''
+    i = np.load(os.path.join(npz_dir, npz))['mmode'].astype(np.uint8)
+    plt.imshow(i, cmap='gray')
+    plt.savefig(os.path.join(save_dir,npz.split('.')[0]) + ".png")
+
+
+def save_mmodes():
+    '''
+    Converts external mmode npzs to pngs. Npz directory must be organized by center, then class.
+    '''
+    npz_root = cfg['EXTERNAL_VAL']['PATHS']['NPZS']
+    save_root = cfg['EXTERNAL_VAL']['PATHS']['PNGS']
+    for center in cfg['EXTERNAL_VAL']['LOCATIONS']:
+        for label in ['sliding', 'no_sliding']:
+            npz_path = os.path.join(npz_root, center, label)
+            save_path = os.path.join(save_root, center, label)
+            if not os.path.isdir(save_path):
+                os.makedirs(save_path)
+                print('new dir created at {}'.format(save_path))
+            for root, dir, files in os.walk(npz_path):
+                print(len(files))
+                for file in files:
+                    if file.split("_")[1] == '1.npz': # Only save the first (brightest pixel) m-mode for each clip
+                        export_mmode_to_png(file,npz_path,save_path)
+
+
+if __name__ == '__main__':
+    exp_dir = os.path.join(os.getcwd() + cfg['PATHS']['EXPERIMENTS'])
+    exp_path = os.path.join(exp_dir, os.listdir(exp_dir)[-1])
+
+    # Plot overall results
+    plot_finetune_results(exp_path, flip_labels=False)
+
+    # Plot results by probe type
+    plot_subgroup_analysis_results(exp_path, flip_labels=False, group='probe')
+
+    # Plot mean sensitivity and specificity
+    plot_mean_sensitivity_specificity_tradeoff(exp_path, flip_labels=False, print_metrics=True)
+
+
+
+

--- a/src/data/results/finetune_results_utils.py
+++ b/src/data/results/finetune_results_utils.py
@@ -26,7 +26,7 @@ def finetune_results_to_csv(experiment_path):
     # Combine results across all trials.
     for trial in trial_folders:
         metric_results_csv_path = glob.glob(os.path.join(trial, '*.csv'))[1]
-        metric_results_csv = pd.read_csv(metric_results_csv_path, index_col=0)
+        metric_results_csv = pd.read_csv(metric_results_csv_path)
         trial_numbers.extend([cur_trial_num] * len(metric_results_csv))
         trial_results = pd.concat([trial_results, metric_results_csv])
         cur_trial_num += 1
@@ -49,6 +49,7 @@ def plot_finetune_results(results_csv):
     :param results_csv: Absolute path to .csv file containing fine-tuning results.
     '''
     results_df = pd.read_csv(results_csv)
+    num_trials = len(glob.glob(os.path.split(results_csv)[0] + '/trial_*'))
 
     # The absolute path to the corresponding experiment is the parent directory for the results .csv file.
     experiment_path = '\\'.join(results_csv.split('\\')[:-1])
@@ -64,10 +65,9 @@ def plot_finetune_results(results_csv):
 
     # Get list of external data proportions used for training in the experiment.
     first_trial_results = results_df[results_df['trial'] == 1]
-    ext_data_props = first_trial_results[first_trial_results['variable_sized_test_set'] == 1]['ext_data_prop'].values
+    ext_data_props = first_trial_results[first_trial_results['variable_size_test_set'] == 1]['train_data_prop'].values
 
     metrics = cfg['PLOT_METRICS']
-    num_trials = cfg['NUM_TRIALS']
     plot_ind = 0
     legend_labels = []
 
@@ -83,7 +83,7 @@ def plot_finetune_results(results_csv):
             style = 'solid'
             if test_set_type == 0:
                 style = 'dashed'
-            results_for_test_set_type = results_df[results_df['variable_sized_test_set'] == test_set_type]
+            results_for_test_set_type = results_df[results_df['variable_size_test_set'] == test_set_type]
             test_set_size_label = '({} Test Set Size)'.format('Variable' if test_set_type == 1 else 'Fixed')
 
             # Plot results for each trial.
@@ -99,7 +99,7 @@ def plot_finetune_results(results_csv):
             # Plot average metric value across trials.
             trial_avgs = []
             for prop in ext_data_props:
-                avg_for_prop = np.mean(results_for_test_set_type[results_for_test_set_type['variable_sized_test_set'] ==
+                avg_for_prop = np.mean(results_for_test_set_type[results_for_test_set_type['variable_size_test_set'] ==
                                                                  test_set_type][metric])
                 trial_avgs.append(avg_for_prop)
 
@@ -119,11 +119,11 @@ def plot_finetune_results(results_csv):
         legend_labels = []
 
 #
-# experiment_path = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
-# experiment_path = os.path.join(experiment_path, os.listdir(experiment_path)[-1])
-# res_df = finetune_results_to_csv(experiment_path)
-#
-# plot_finetune_results(res_df)
+experiment_path = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
+experiment_path = os.path.join(experiment_path, os.listdir(experiment_path)[-1])
+res_df = finetune_results_to_csv(experiment_path)
+
+plot_finetune_results(res_df)
 
 # if __name__ == '__main__':
 #     exp_dir = os.path.join(os.getcwd() + cfg['PATHS']['EXPERIMENTS'])

--- a/src/data/results/finetune_results_utils.py
+++ b/src/data/results/finetune_results_utils.py
@@ -25,7 +25,7 @@ def finetune_results_to_csv(experiment_path):
 
     # Combine results across all trials.
     for trial in trial_folders:
-        metric_results_csv_path = glob.glob(os.path.join(trial, '*.csv'))[0]
+        metric_results_csv_path = glob.glob(os.path.join(trial, '*.csv'))[1]
         metric_results_csv = pd.read_csv(metric_results_csv_path, index_col=0)
         trial_numbers.extend([cur_trial_num] * len(metric_results_csv))
         trial_results = pd.concat([trial_results, metric_results_csv])
@@ -118,10 +118,16 @@ def plot_finetune_results(results_csv):
         plot_ind += 1
         legend_labels = []
 
-
+#
 # experiment_path = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
 # experiment_path = os.path.join(experiment_path, os.listdir(experiment_path)[-1])
 # res_df = finetune_results_to_csv(experiment_path)
 #
 # plot_finetune_results(res_df)
 
+# if __name__ == '__main__':
+#     exp_dir = os.path.join(os.getcwd() + cfg['PATHS']['EXPERIMENTS'])
+#     exp_path = glob.glob(os.path.join(exp_dir, 'experiment_1660921548.0\\trial_1\\upsample_miniclips.csv'))[0]
+#     upsample_csv = pd.read_csv(exp_path)
+#     print(len(upsample_csv))
+#     print(upsample_csv.loc[upsample_csv.duplicated(subset=['miniclip_id'])])

--- a/src/data/results/finetune_results_utils.py
+++ b/src/data/results/finetune_results_utils.py
@@ -119,8 +119,8 @@ def plot_finetune_results(results_csv):
         legend_labels = []
 
 
-experiment_path = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
-experiment_path = os.path.join(experiment_path, os.listdir(experiment_path)[-1])
-res_df = finetune_results_to_csv(experiment_path)
-
-plot_finetune_results(res_df)
+# experiment_path = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
+# experiment_path = os.path.join(experiment_path, os.listdir(experiment_path)[-1])
+# res_df = finetune_results_to_csv(experiment_path)
+#
+# plot_finetune_results(res_df)

--- a/src/data/results/finetune_results_utils.py
+++ b/src/data/results/finetune_results_utils.py
@@ -1,0 +1,95 @@
+import pandas as pd
+import os
+import yaml
+import matplotlib.pyplot as plt
+from src.data.sql_utils import add_date_to_filename
+from src.data.utils import refresh_folder
+
+cfg = yaml.full_load(open(os.path.join(os.getcwd(), "config.yml"), 'r'))['EXTERNAL_VAL']
+
+
+def finetune_results_to_csv(experiment_path=os.getcwd() + cfg['PATHS']['EXPERIMENTS']):
+    '''
+    Saves finetune results for each trial (and for each fold in that trial) as a csv file.
+    :param experiment_path: Full path to fine-tuning experiment files.
+    :return Str: Full path to the .csv file containing finetuning results across all trials.
+    '''
+    trial_results = []
+    for result_csv in os.listdir(experiment_path):
+        # The experiment folder also contains a subdirectory for plots. Skip over this to get to the actual result csvs.
+        if os.path.isdir(os.path.join(experiment_path, result_csv)):
+            continue
+        trial_results.append(pd.read_csv(os.path.join(experiment_path, result_csv)))
+
+    trial_results = pd.concat(trial_results, ignore_index=True)
+    num_trials = cfg['NUM_TRIALS']
+    num_data_slices = len(os.listdir(experiment_path)) // num_trials
+    ext_data_props = [(n + 1) / num_trials for n in range(num_data_slices)] * num_trials
+    ext_data_props = pd.DataFrame(ext_data_props, columns=['ext_train_prop'])
+    trial_index = []
+    for t in range(num_trials):
+        trial_index.extend([t + 1] * num_data_slices)
+    trial_index = pd.DataFrame(trial_index, columns=['trial'])
+    trial_results = pd.concat([trial_index, ext_data_props, trial_results], axis=1)
+    print(trial_results)
+    # Adding '_df.csv' to the end of the resulting file name gets rid of permission error. Might want to investigate
+    # this further.
+    final_path = os.path.join(os.getcwd() + cfg['PATHS']['CSV_OUT'], add_date_to_filename('experiment_results') + '_df.csv')
+    trial_results.to_csv(final_path)
+    return final_path
+
+
+def plot_finetune_results(results_csv):
+    '''
+    Plots finetuning results for metrics specified in the config file (currently loss/sensitivity/specificity). Plots
+    results by individual trial along with trial-wise averages for each metric.
+    :param results_csv: Full path to .csv file containing fine-tuning results
+    '''
+    results_df = pd.read_csv(results_csv)
+    num_trials = cfg['NUM_TRIALS']
+    num_data_slices = len(results_df) // num_trials
+    # Set up the x-axis for plotting.
+    x = list(results_df['ext_train_prop'])[:num_data_slices]
+    plot_metrics = cfg['PLOT_METRICS']
+    path_to_plots = os.getcwd() + cfg['PATHS']['PLOTS']
+    if cfg['REFRESH_FOLDERS']:
+        refresh_folder(path_to_plots)
+    # Extract metric values from result df. Generate plots and save them.
+    plt_ind = 0
+    for metric in plot_metrics:
+        metric_values = results_df[metric].values
+        y = []
+        for i in range(0, len(metric_values), num_data_slices):
+            y.append(metric_values[i:i + num_data_slices])
+        plt.figure(plt_ind)
+        for trial_y in y:
+            plt.plot(x, trial_y)
+        # Compute trial-wise average metric value
+        trial_avgs = []
+        for i in range(num_data_slices):
+            total = 0
+            for j in range(num_trials):
+                total += metric_values[i + j * num_data_slices]
+            avg = total / num_trials
+            trial_avgs.append(avg)
+        plt.plot(x, trial_avgs, linestyle='dashed')
+        plt.xticks(x)
+        plt.xlabel('External Training Data Proportion')
+        # Sensitivity and specificity metric values need to be flipped to follow convention with original lung sliding
+        # manuscript.
+        if metric == 'sensitivity':
+            metric = 'specificity'
+        elif metric == 'specificity':
+            metric = 'sensitivity'
+        # Capitalize the name of the metric
+        y_axis_label = metric[0].upper() + metric[1:]
+        plt.ylabel(y_axis_label)
+        plt.title(y_axis_label + ' vs Proportion of External Data as Train Set')
+        legend_strs = []
+        for i in range(num_trials):
+            legend_strs.append('Trial ' + str(i + 1))
+        legend_strs.append('Average ' + y_axis_label + ' (Trial-Wise)')
+        plt.legend(legend_strs)
+        plt.savefig(os.path.join(path_to_plots, add_date_to_filename(metric) + '.jpg'))
+        plt_ind += 1
+

--- a/src/data/save_m_modes.py
+++ b/src/data/save_m_modes.py
@@ -111,18 +111,3 @@ if __name__ == '__main__':
     project_dir = '\\'.join(os.getcwd().split('\\')[:-2])
     external_m_mode_peek(30, project_dir + cfg_full['EXTERNAL_VAL']['PATHS']['NPZS'],
                          project_dir + '\\mmode_sample')
-    # raw_clips_dir = cfg['PATHS']['MASKED_VIDEOS']
-    # short_clips = []
-    # for clip_class in os.listdir(raw_clips_dir):
-    #     clip_class_dir = os.path.join(raw_clips_dir, clip_class)
-    #     for clip in os.listdir(clip_class_dir):
-    #         # Get clip length.
-    #         l = get_clip_length(os.path.join(clip_class_dir, clip))
-    #         if l < 3.0:
-    #             short_clips.append(os.path.join(clip_class_dir, clip))
-    # # Show the filenames of all clips less than the mini-clip window specified in the config file.
-    # for clip in short_clips:
-    #     print(clip)
-    # print(len(short_clips))
-    #
-    # save_m_modes(npz_dir, mmode_dir)

--- a/src/data/save_m_modes.py
+++ b/src/data/save_m_modes.py
@@ -2,18 +2,21 @@ import os
 import numpy as np
 import yaml
 import cv2
+import glob
+import random
+import shutil
 from utils import refresh_folder
 
 cfg = yaml.full_load(open(os.path.join(os.getcwd(), "..\\..\\config.yml"), 'r'))['PREPROCESS']
 cfg_full = yaml.full_load(open(os.path.join(os.getcwd(), "..\\..\\config.yml"), 'r'))
 
-mmode_dir = cfg_full['GENERALIZE']['PATHS']['MMODES']
+mmode_dir = cfg_full['EXTERNAL_VAL']['PATHS']['MMODES']
 npz_dir = cfg['PATHS']['NPZ']
 
 if not os.path.exists(mmode_dir):
     os.makedirs(mmode_dir)
 
-if cfg_full['GENERALIZE']['REFRESH_FOLDERS']:
+if cfg_full['EXTERNAL_VAL']['REFRESH_FOLDERS']:
     refresh_folder(mmode_dir)
 
 
@@ -45,19 +48,81 @@ def get_clip_length(video_path):
     return duration
 
 
-if __name__ == '__main__':
-    raw_clips_dir = cfg['PATHS']['MASKED_VIDEOS']
-    short_clips = []
-    for clip_class in os.listdir(raw_clips_dir):
-        clip_class_dir = os.path.join(raw_clips_dir, clip_class)
-        for clip in os.listdir(clip_class_dir):
-            # Get clip length.
-            l = get_clip_length(os.path.join(clip_class_dir, clip))
-            if l < 3.0:
-                short_clips.append(os.path.join(clip_class_dir, clip))
-    # Show the filenames of all clips less than the mini-clip window specified in the config file.
-    for clip in short_clips:
-        print(clip)
-    print(len(short_clips))
+def external_m_mode_peek(n, npz_dir, save_dir, pull_by_loc=True):
+    '''
+    Saves n of the M-modes into save_dir. Pulls approximately the same number of M-modes from each multi-center location
+    if pull_by_loc is set to True. Note: The M-modes are pulled from npz_dir.
+    :param n: Number of M-mode images to pull.
+    :param npz_dir: Directory from which to retrieve .npz files. These files are converted to M-modes. Absolute path.
+    :param save_dir: Directory to which to save the n M-modes. Absolute path.
+    :param pull_by_loc: Defaults to True. If True, then M-modes are evenly pulled by multi-center location.
+    '''
+    npzs = []
 
-    save_m_modes(npz_dir, mmode_dir)
+    # If pull_by_loc is True, then pull M-modes evenly by location.
+    if pull_by_loc:
+        num_clips = []
+        locs = cfg_full['EXTERNAL_VAL']['LOCATIONS']
+        num_loc = len(locs)
+        n_per_loc = n // num_loc
+        for i in range(num_loc):
+            num_clips.append(n_per_loc)
+        num_clips[0] += n - n_per_loc * num_loc
+
+        # Get n random .npzs to convert to M-modes. Do so evenly by location.
+        for i in range(len(num_clips)):
+            print(os.path.join(npz_dir, locs[i]))
+            for input_class in ['sliding', 'no_sliding']:
+                npzs_for_loc = glob.glob(os.path.join(npz_dir, locs[i], input_class, '*.npz'))
+                random.shuffle(npzs)
+                npzs_to_convert = npzs_for_loc[:(num_clips[i] // 2)]
+                npzs.extend(npzs_to_convert)
+
+    else:
+        for loc in cfg_full['EXTERNAL_VAL']['LOCATIONS']:
+            for input_class in ['sliding', 'no_sliding']:
+                npzs.extend(glob.glob(os.path.join(npz_dir, loc, input_class, '*.npz')))
+        random.shuffle(npzs)
+        npzs = npzs[:n]
+
+    if not os.path.exists(save_dir):
+        os.makedirs(save_dir)
+    else:
+        refresh_folder(save_dir)
+
+    # Temporarily store the .npzs in save_dir.
+    for file in npzs:
+        filename = file.split('\\')[-1]
+        shutil.copy(file, os.path.join(save_dir, filename))
+
+    for file in glob.glob(os.path.join(save_dir, '*.npz')):
+        n = np.load(file)
+        arr = (n['mmode'])
+        path_parts = file.split('\\')
+        save_path = os.path.join('\\'.join(path_parts[:-1]), path_parts[-1][:-4] + '.jpg')
+        cv2.imwrite(save_path, arr)
+
+    # Remove .npzs from M-mode directory.
+    for file in glob.glob(os.path.join(save_dir, '*.npz')):
+        os.remove(file)
+
+
+if __name__ == '__main__':
+    project_dir = '\\'.join(os.getcwd().split('\\')[:-2])
+    external_m_mode_peek(30, project_dir + cfg_full['EXTERNAL_VAL']['PATHS']['NPZS'],
+                         project_dir + '\\mmode_sample')
+    # raw_clips_dir = cfg['PATHS']['MASKED_VIDEOS']
+    # short_clips = []
+    # for clip_class in os.listdir(raw_clips_dir):
+    #     clip_class_dir = os.path.join(raw_clips_dir, clip_class)
+    #     for clip in os.listdir(clip_class_dir):
+    #         # Get clip length.
+    #         l = get_clip_length(os.path.join(clip_class_dir, clip))
+    #         if l < 3.0:
+    #             short_clips.append(os.path.join(clip_class_dir, clip))
+    # # Show the filenames of all clips less than the mini-clip window specified in the config file.
+    # for clip in short_clips:
+    #     print(clip)
+    # print(len(short_clips))
+    #
+    # save_m_modes(npz_dir, mmode_dir)

--- a/src/data/sql_utils.py
+++ b/src/data/sql_utils.py
@@ -3,13 +3,15 @@ import os
 import yaml
 import pandas as pd
 import datetime
+import time
 
 database_cfg = yaml.full_load(open(os.path.join(os.getcwd(), "database_config.yml"), 'r'))
 
 
 def get_clips_from_db(table_name, sliding=True):
     '''
-    Pulls clips from database using specified MySQL query.
+    Pulls clips from table specified by table_name. Specify whether to pull present or absent sliding clips using the
+    sliding parameter.
     :param table_name: Str, indicates location from the multi-center study for which to pull clips.
     :param sliding: Bool, set to True to pull present lung sliding clips. Set to False to pull absent lung sliding clips.
     '''
@@ -54,10 +56,11 @@ def get_clips_from_db(table_name, sliding=True):
 
 def add_date_to_filename(file):
     '''
-    Labels a file name with useful information about date and time.
+    Labels a file name with a Unix timestamp.
     :param file: name of file as string
-    :return labelled_filename: name of file joined with date and time info.
+    :return labelled_filename: name of file joined with date and time info (Unix format).
     '''
-    cur_date = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
-    labelled_filename = file + '_' + cur_date
+    cur_date = datetime.datetime.now()
+    cur_date = time.mktime(cur_date.timetuple())
+    labelled_filename = file + '_' + str(cur_date)
     return labelled_filename

--- a/src/data/sql_utils.py
+++ b/src/data/sql_utils.py
@@ -1,0 +1,63 @@
+import mysql.connector
+import os
+import yaml
+import pandas as pd
+import datetime
+
+database_cfg = yaml.full_load(open(os.path.join(os.getcwd(), "database_config.yml"), 'r'))
+
+
+def get_clips_from_db(table_name, sliding=True):
+    '''
+    Pulls clips from database using specified MySQL query.
+    :param table_name: Str, indicates location from the multi-center study for which to pull clips.
+    :param sliding: Bool, set to True to pull present lung sliding clips. Set to False to pull absent lung sliding clips.
+    '''
+    # Get database configs
+    user = database_cfg['USERNAME']
+    password = database_cfg['PASSWORD']
+    host = database_cfg['HOST']
+    db = database_cfg['DATABASE']
+
+    # Establish connection to database
+    cnx = mysql.connector.connect(user=user, password=password, host=host, database=db)
+
+    # initialize pleural_line_findings query condition
+    pleural_line_findings = " is null OR pleural_line_findings='thickened'"
+
+    # adjust pleural_line_findings query condition as needed
+    if table_name == 'clips_chile':
+        if sliding:
+            pleural_line_findings = "='' OR pleural_line_findings='thickened'"
+    if not sliding:
+        pleural_line_findings = "='absent_lung_sliding'"
+
+    # set up the MySQL query
+    query = "SELECT * FROM {} WHERE view='parenchymal' AND a_or_b_lines='a_lines'" \
+            " AND (quality NOT LIKE '%significant_probe_movement%' OR quality is null)" \
+            " AND (pleural_line_findings{}"\
+        .format(table_name, pleural_line_findings)
+
+    # If pulling Alberta data, ensure that these clips have been reviewed and are ready to use!
+    if table_name == 'clips_alberta':
+        query += ' AND reviewed=1 AND do_not_use=0'
+        if not sliding:
+            pleural_line_findings += "='absent_lung_sliding' OR pleural_line_findings='thickened|absent_lung_sliding'"
+
+    # Complete query syntax
+    query += ');'
+
+    # pull clips from the database into a DataFrame
+    clips_df = pd.read_sql(query, cnx)
+    return clips_df
+
+
+def add_date_to_filename(file):
+    '''
+    Labels a file name with useful information about date and time.
+    :param file: name of file as string
+    :return labelled_filename: name of file joined with date and time info.
+    '''
+    cur_date = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
+    labelled_filename = file + '_' + cur_date
+    return labelled_filename

--- a/src/data/to_npz.py
+++ b/src/data/to_npz.py
@@ -82,6 +82,8 @@ def miniclip_to_mmode(clip, bounding_box, height_width,method=None):
     :param clip: LUS clip
     :param bounding_box: Tuple of (ymin, xmin, ymax, xmax) of pleural line ROI
     :param height_width: original LUS frame dimensions before resizing
+    :param method: If not None, specifies the method to use for the miniclip to mmode conversion. If None, method
+                   used defaults to that specified in the config under 'TRAIN' > M_MODE_SLICE_METHOD
     '''
     # Extract m-mode
     num_frames, new_height, new_width = clip.shape[0], clip.shape[1], clip.shape[2]

--- a/src/data/to_npz.py
+++ b/src/data/to_npz.py
@@ -101,7 +101,7 @@ def miniclip_to_mmode(clip, bounding_box, height_width):
 
 
 def video_to_frames_contig(orig_id, patient_id, df_rows, cap, seq_length=cfg['PARAMS']['WINDOW_SECONDS'],
-                           resize=cfg['PARAMS']['IMG_SIZE'], write_path='', box=None):
+                           resize=cfg['PARAMS']['IMG_SIZE'], write_path='', box=None, n_mmodes=1):
 
     '''
     Converts a LUS video file to contiguous-frame mini-clips with specified sequence length
@@ -114,6 +114,7 @@ def video_to_frames_contig(orig_id, patient_id, df_rows, cap, seq_length=cfg['PA
     :param resize: [width, height], dimensions to resize frames to before saving
     :param write_path: Path to directory where output mini-clips are saved
     :param box: Tuple of (ymin, xmin, ymax, xmax) of pleural line ROI
+    :param n_mmodes: Number of M-Mode images to sample
     '''
 
     fr = round(cap.get(cv2.CAP_PROP_FPS))
@@ -136,8 +137,12 @@ def video_to_frames_contig(orig_id, patient_id, df_rows, cap, seq_length=cfg['PA
             if counter == 0:
                 # append to what will make output dataframes
                 df_rows.append([orig_id + '_' + str(mini_clip_num), patient_id])
-                mmode = miniclip_to_mmode(np.array(frames), box, (cap_height, cap_width))
-                np.savez_compressed(write_path + '_' + str(mini_clip_num), mmode=mmode)  # output
+                for i in range(1, n_mmodes + 1):
+                    mmode = miniclip_to_mmode(np.array(frames), box, (cap_height, cap_width))
+                    npz_path = write_path + '_' + str(mini_clip_num)
+                    if i > 1:
+                        npz_path = npz_path + f"_{i}"
+                    np.savez_compressed(npz_path, mmode=mmode)  # output
                 counter = seq_length
                 mini_clip_num += 1
                 frames = []

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -342,7 +342,7 @@ def linear_upsample(dataset, raw_dataset, linear_frac):
 
 def reinitialize_layer(model, initializer, layer_name):
     '''
-    Re-initializes the weights of a specific layer of the model froma  desired distirbution.
+    Re-initializes the weights of a specific layer of the model from a desired distirbution.
     :param model: model with the layer to be re-initialized
     :param initializer: desired Tensorflow initializer used to initialize the weights
     :param layer_name: name of the layer to be re-initialized
@@ -364,6 +364,7 @@ def finetune_model(original_model_path, base_folder, full_train_df, mmode_prepro
     :param upsample: If set to True, upsamples the minority class in the training set according to the configured ratio
     :param seed: Random seed for fold sampling
     :param AB_scheme: If True, fine-tunes using the approach from our AB manuscript (10 epochs at LR, n epochs at LR/10)
+                      Manuscript link: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8621216/pdf/diagnostics-11-02049.pdf
     :param reinitialize: If True, final 5 FC layers are re-initialized from a truncated normal distribution with mean 0
     :param focal_loss: If True, sigmoid focal loss entropy is used for the loss Otherwise, binary cross entropy is used.
     :param set_class_weight: If True, the class_weight parameter is set in model.fit().
@@ -505,7 +506,6 @@ def finetune_model(original_model_path, base_folder, full_train_df, mmode_prepro
 
 
 def TAAFT(clip_df, n_folds, experiment_path=None, seed=None, hparams=None, stratify_by=None):
-          #by_center=False, by_probe=False):
     '''
     Executes a trial of TAAFT (Threshold-Aware Accumulative Fine-Tuning).
     Divides clips into random folds, then runs fine-tuning trials with progressively larger training sets. Evaluates

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -149,7 +149,7 @@ def get_eval_results(model_path, test_df, metrics, save_pred_labels=True, verbos
         ids = pd.DataFrame(test_df['id'], columns=['id']).reset_index(drop=True)
         pred_label_df = pd.concat([ids, pred_labels_col, probs_col], axis=1)
 
-    conf_mtrx = confusion_matrix(y_true=test_df['label'], y_pred=np.rint(probs).astype(np.int))
+    conf_mtrx = confusion_matrix(y_true=test_df['label'], y_pred=np.rint(probs))
 
     results = []
     metric_names = []
@@ -215,15 +215,14 @@ def upsample_absent_sliding_data(train_df, upsample_df, prop, absent_pct, method
     '''
 
     no_upsampled_train_df = train_df
-    if len(upsample_df) != 0:
-        no_upsampled_train_df = train_df[~train_df['id'].isin(upsample_df['miniclip_id'])]
+    # if len(upsample_df) != 0:
+    #     no_upsampled_train_df = train_df[~train_df['id'].isin(upsample_df['miniclip_id'])]
 
     # Get sliding and no-sliding subsets of train_df.
     sliding_df = no_upsampled_train_df[no_upsampled_train_df['label'] == 1]
     no_sliding_df = no_upsampled_train_df[no_upsampled_train_df['label'] == 0]
 
     sliding_df = sliding_df.reset_index(drop=True)
-    no_sliding_df = no_sliding_df
 
     # Shuffle no_sliding_df. We do this to facilitate random duplicate up-sampling from the no-sliding dataframe.
     # I.e we draw miniclips to duplicate from a shuffled no-sliding df.
@@ -233,20 +232,15 @@ def upsample_absent_sliding_data(train_df, upsample_df, prop, absent_pct, method
     num_upsampled = int(absent_pct * (len(sliding_df) / (1 - absent_pct)))
 
     upsample_set = no_sliding_df.iloc[:(num_upsampled - len(no_sliding_df))]
-
-    # Put new upsample col and new ext data prop col here.
-    upsample_col = pd.DataFrame([1] * len(upsample_set), columns=['upsampled']).reset_index(drop=True)
     ext_data_props = pd.DataFrame([prop] * len(upsample_set), columns=['ext_data_prop']).reset_index(drop=True)
 
     upsample_ids = upsample_set['id']
     upsample_ids = pd.DataFrame({'miniclip_id': upsample_ids})
     upsample_ids = upsample_ids.reset_index(drop=True)
-    new_upsampled = pd.concat([ext_data_props, upsample_ids, upsample_col], axis=1)
-
+    new_upsampled = pd.concat([ext_data_props, upsample_ids], axis=1).reset_index(drop=True)
     new_upsampled_df = pd.concat([upsample_df, new_upsampled])
 
     no_sliding_df = pd.concat([no_sliding_df, upsample_set])
-    no_sliding_df.update(pd.DataFrame(upsample_col))
     print('Sliding: {}'.format(len(sliding_df)))
     print('No Sliding: {}'.format(len(no_sliding_df)))
     new_train_df = pd.concat([sliding_df, no_sliding_df])
@@ -278,6 +272,7 @@ class TAAFT:
         id in the fold on a new line.
         :param trial_folder: Absolute path to folder in which to place patient folds. Corresponds to a particular trial.
         '''
+
         sliding_df = self.mini_clip_df[self.mini_clip_df['label'] == 1]
         no_sliding_df = self.mini_clip_df[self.mini_clip_df['label'] == 0]
 
@@ -303,159 +298,117 @@ class TAAFT:
         elif overwrite:
             open(folds_path, "w").close()
 
-        # Populate the file to store ids by fold.
-        folds = []
-        cur_fold = []
-
         # Keep track of the desired sizes for each fold. Since not all folds will be of the same size in terms
         # of patient ids, this eliminates the need to dynamically compute each fold size.
         n_folds = cfg['FOLD_SAMPLE']['NUM_FOLDS']
         fold_sizes = [len(sliding_ids) // n_folds] * n_folds
         fold_sizes[-1] += len(sliding_ids) % n_folds
 
-        # Note: the code block above assumes that, if the number of sliding ids is not perfectly divisible by the
-        # desired number of folds, then we make one fold slightly bigger than the rest. This must be modified if
-        # we choose not to keep the smaller "leftover" fold.
+        folds = []
+        sliding_count = [0] * n_folds
+        no_sliding_count = [0] * n_folds
 
-        sliding_count = 0
-        sliding = []
-        no_sliding = []
+        folds_to_supply = []
 
-        print("Sampling folds...\n")
-        # Populate each fold with sliding ids
-        cur_fold_num = 0
-        for size in fold_sizes:
-            for i in range(size):
-                cur_id = sliding_ids[-1]
-                sliding_ids = sliding_ids[:-1]
-                # Save the portion of the sliding df that contains these patient ids. Save by mini-clip id.
-                clips_by_id = sliding_df[sliding_df['patient_id'] == cur_id]['id']
-                sliding_count += len(clips_by_id)
-                cur_fold.append(clips_by_id)
-            # Each fold is represented as a separate DataFrame. The folds variable is a list of pd.DataFrames.
-            cur_fold = pd.concat(cur_fold)
-            folds.append(cur_fold)
-            cur_fold = []
-            cur_fold_num += 1
-            sliding.append(sliding_count)
-            sliding_count = 0
+        for i in range(n_folds):
+            fold_end = min(fold_sizes[i], len(sliding_ids))
+            cur_ids = sliding_ids[:fold_end]
+            sliding_ids = sliding_ids[fold_sizes[i]:]
+            cur_fold_sliding = sliding_df[sliding_df['patient_id'].isin(cur_ids)]['id']
+            cur_fold_no_sliding = no_sliding_df[no_sliding_df['patient_id'].isin(cur_ids)]['id']
+            sliding_count[i] += len(cur_fold_sliding)
+            no_sliding_count[i] += len(cur_fold_no_sliding)
+            if len(cur_fold_no_sliding) == 0:
+                folds_to_supply.append(i)
+            no_sliding_df = no_sliding_df[~no_sliding_df['patient_id'].isin(cur_ids)]
+            folds.append(pd.concat([cur_fold_sliding, cur_fold_no_sliding]))
 
-        num_folds = len(folds)
+        no_sliding_ids = no_sliding_df['patient_id'].values
+        folds_with_all_sliding = len(folds_to_supply) if len(folds_to_supply) > 0 else n_folds
+        no_sliding_to_add = [len(no_sliding_ids) // folds_with_all_sliding] * folds_with_all_sliding
+        for i in range(len(no_sliding_ids) % folds_with_all_sliding):
+            no_sliding_to_add[i] += 1
 
-        # Distribute non-sliding ids across folds. This is done in a roulette-like manner so that the ratio of negative
-        # to positive classes in each fold is preserved.
-        i = 0
-        while True:
-            if len(no_sliding_ids) == 0:
-                break
-            cur_id = no_sliding_ids[-1]
-            no_sliding_ids = no_sliding_ids[:-1]
-            clips_by_id = no_sliding_df[no_sliding_df['patient_id'] == cur_id]['id']
-            no_sliding_count = len(clips_by_id)
-            temp = folds[i % num_folds]
-            folds[i % num_folds] = pd.concat([temp, clips_by_id])
-            if i < num_folds:
-                no_sliding.append(no_sliding_count)
-            else:
-                no_sliding[i % num_folds] += no_sliding_count
-            i += 1
+        for i, j in zip(no_sliding_to_add, folds_to_supply):
+            folds[j] = pd.concat([folds[j], no_sliding_df.head(i)])
+            no_sliding_df = no_sliding_df.tail(len(no_sliding_df) - i)
 
-        for i in range(num_folds):
-            print("Fold {}: {} clips with lung sliding, {} clips without lung sliding. Negative:Positive ~ {}"
-                  .format(i + 1, sliding[i], no_sliding[i], round(sliding[i] / no_sliding[i], 3)))
+        ratios = []
+        for i in range(n_folds):
+            ratio = no_sliding_count[i] / sliding_count[i]
+            ratios.append(ratio)
+            print('Fold {}: {} sliding, {} no sliding. Absent to present ratio: {}'
+                  .format(i + 1, sliding_count[i], no_sliding_count[i], ratio))
 
-        avg_neg_to_pos_ratio = sum([sliding[i] / no_sliding[i] for i in range(len(folds))]) / len(folds)
-        print("Average negative:positive ratio ~ {}\n".format(round(avg_neg_to_pos_ratio)))
+        print('Average absent to present ratio: {}'.format(sum(ratios) / n_folds))
 
         # Write the folds to the fold file:
         if cfg['FOLD_SAMPLE']['OVERWRITE_FOLDER']:
             refresh_folder(os.getcwd() + cfg['PATHS']['FOLDS'])
         write_folds_to_csv(folds, folds_path)
 
-        print("Sampling complete with seed = " + str(cfg['FOLD_SAMPLE']['SEED']) +
-              ". Folds saved to " + folds_path + ".")
-
-    def finetune_single_trial(self, trial_folder, hparams=None, lazy=True):
+    def finetune_single_trial(self, trial_folder, hparams=None, lazy=True, upsample=True):
         '''
         Performs a single fine-tuning trial. Fine-tunes a model on external clip data, repeatedly augmenting external
         data slices to a training set until all external data has been used for training.
         :param trial_folder: Absolute path to folder in which to place metrics for current trial.
         :param hparams: Specifies the set of hyperparameters for fine-tuning the model.
         :param lazy: When True, trial will terminate once model performance exceeds minimum thresholds.
+        :param upsample: When True, upsamples absent sliding mini-clips in each training set during fine-tuning.
         '''
+
+        original_model_path = os.path.join(os.getcwd(), cfg_full['PREDICT']['MODEL'])
+        metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
 
         # Set up result directories for given trial; read values from config file.
         model_out_dir = os.path.join(trial_folder, 'models')
         if not os.path.exists(model_out_dir):
             os.makedirs(model_out_dir)
 
+        # Set up the labelled external dataframe for augmenting the training data.
+        ext_df = self.mini_clip_df
+
+        # This df will store trial results.
+        trial_results_df = pd.DataFrame([])
+
+        # Get results for original model before fine-tuning.
+        res_df, _ = get_eval_results(original_model_path, ext_df, metrics)
+        trial_results_df = pd.concat([trial_results_df, res_df])
+        original_model = load_model(original_model_path, compile=False)
+        original_model.save(os.path.join(model_out_dir, 'model_0.0_percent_train'))
+
         model_name = cfg_full['TRAIN']['MODEL_DEF'].lower()
         hparams = cfg_full['TRAIN']['PARAMS'][model_name.upper()] if hparams is None else hparams
 
-        upsample_miniclips_path = os.path.join(trial_folder, 'upsample_miniclips.csv')
-        upsample_df = pd.DataFrame([], columns=['ext_data_prop', 'miniclip_id', 'upsampled'])
+        model_def = cfg_full['TRAIN']['MODEL_DEF'].upper()
+        model_config = cfg_full['TRAIN']['PARAMS'][model_def]
 
         # Retrieve patient folds (stored by clip ids).
         filename = glob.glob(os.path.join(trial_folder, 'folds*.csv'))[0]
-        folds_file = os.path.join(trial_folder, filename)
-        folds = pd.read_csv(folds_file)
-        cur_fold = []
-        # stores the folds extracted from the txt file. Each fold is a pd.DataFrame.
-        fold_list = []
-
-        for i in range(1, cfg['FOLD_SAMPLE']['NUM_FOLDS'] + 1):
-            fold_list.append(folds[folds['fold_number'] == i])
-
-        print("Retrieved {} external patient folds. The lengths of each fold are: ".format(len(fold_list)),
-              [len(fold) for fold in fold_list])
-
-        # set up the labelled external dataframe for augmenting the training data
-        labelled_ext_df_dir = os.path.join(os.getcwd() + cfg['PATHS']['CSV_OUT'], 'labelled_external_dfs')
-        ext_df = pd.read_csv(glob.glob(os.path.join(labelled_ext_df_dir, '*.csv'))[0])
+        folds = pd.read_csv(filename)
 
         train_df = pd.DataFrame([])
 
-        print('Setup complete')
+        # If absent sliding mini-clips are to be upsampled, create a df for saving these upsampled mini-clips.
+        upsample_df = pd.DataFrame([])
+        upsample_miniclips_path = os.path.join(trial_folder, 'upsample_miniclips.csv')
 
-        # Fine-tuning trial starts here.
-        cur_fold_num = 0
-        num_folds_added = 0  # number of external data slices that have been added to the training set
         min_test_size = int(len(ext_df) * cfg['MIN_TEST_SIZE'])
 
-        # # After .npz conversion, clip ids are followed by indices. Ignore these indices for patient id retrieval by
-        # # clip id.
-        # original_clip_ids = pd.DataFrame(ext_df['id'].str[:-2], columns=['id'])
-        # clip_id_count = original_clip_ids.groupby('id').transform('count')
-        # original_clip_ids = pd.concat([original_clip_ids, clip_id_count], axis=1)
-        # ext_df = ext_df.rename(columns={'id': 'miniclip_id'})
-        # ext_df = pd.concat([original_clip_ids, ext_df], axis=1)
-        
-        trial_results_df = pd.DataFrame([])
-
-        # This will later become a column for external data proportions in the trial result df.
+        cur_fold_num = 0
         props = [0]
+        while len(ext_df) > min_test_size:
+            print('Fine-tuning: {} of {} external data slices...'
+                  .format(cur_fold_num + 1, cfg['FOLD_SAMPLE']['NUM_FOLDS']))
+            fold_to_add = folds[folds['fold_number'] == cur_fold_num + 1]
+            train_df = pd.concat([train_df, ext_df[ext_df['id'].isin(fold_to_add['id'])]])
+            ext_df = ext_df[~ext_df['id'].isin(fold_to_add['id'])]
 
-        # Loop until external testing set has reached minimum size.
-        while len(ext_df) >= min_test_size:
-            print('\n======================= FINE-TUNING ON {} OF {} SLICES OF EXTERNAL DATA ========================\n'
-                  .format(str(num_folds_added + 1), len(fold_list)))
-            # Evaluate the model on the external test set. Note that we load the original pre-finetuned model at each
-            # iteration to minimize co-dependence between runs of a given trial.
-            print('Evaluating model performance before fine-tuning...')
-            # Can change these metrics as necessary
+            # Model starts out as the original model, but then gets fine-tuned.
+            model = original_model
             metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
 
-            # Get evaluation results on model before fine-tuning.
-            original_model_path = os.path.join(os.getcwd(), cfg_full['PREDICT']['MODEL'])
-            res_df, _ = get_eval_results(original_model_path, ext_df, metrics)
-
-            model = load_model(original_model_path, compile=False)
-
-            # Read original model params from config file. Store into model_config.
-            model_def = cfg_full['TRAIN']['MODEL_DEF'].upper()
-            model_config = cfg_full['TRAIN']['PARAMS'][model_def]
-
-            # Freeze layers
+            # Freeze some layers.
             freeze_cutoff = -1 if model_config['BLOCKS_FROZEN'] == 0 else model_config['BLOCKS_FROZEN']
             for i in range(len(model.layers)):
                 if i <= freeze_cutoff:
@@ -464,47 +417,26 @@ class TAAFT:
                 elif ('batch' in model.layers[i].name) or ('bn' in model.layers[i].name):
                     model.layers[i].trainable = False
 
-            # Save the model's loss/sens/spec results from before fine-tuning.
-            if num_folds_added == 0:
-                trial_results_df = pd.concat([trial_results_df, res_df])
-                # Save the original model in the trial's model directory
-                if not lazy or check_performance(res_df):
-                    print('Saving original model...')
-                    model.save(os.path.join(model_out_dir, 'model_0.0_percent_train'))
-                    if lazy:
-                        return
+            if upsample:
+                # cur_ext_prop is the current external data proportion used for training
+                cur_ext_prop = (cur_fold_num + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS']
+                train_df, upsample_df = upsample_absent_sliding_data(train_df, upsample_df, cur_ext_prop, 0.25)
 
-            # Set aside some external data to be added to the existing training data.
-            add_set = fold_list[num_folds_added]
-            add_df = ext_df[ext_df['id'].isin(add_set['id'])]
-
-            # Remove the newly-added training data from the external dataset. Becomes the new testing set.
-            ext_df = ext_df[~ext_df['id'].isin(add_df['id'])]
-
-            # Update the training dataset with the new patient-wise fold. Up-sample as necessary.
-            train_df = pd.concat([train_df, add_df])
-
-            train_df, upsample_df = upsample_absent_sliding_data(train_df, upsample_df,
-                                                                 (num_folds_added + 1) / len(fold_list), 0.25)
-
-            if os.path.exists(upsample_miniclips_path):
-                os.remove(upsample_miniclips_path)
-            upsample_df.to_csv(upsample_miniclips_path)
+                # Update the upsampled mini-clips .csv file.
+                if os.path.exists(upsample_miniclips_path):
+                    os.remove(upsample_miniclips_path)
+                upsample_df.to_csv(upsample_miniclips_path)
 
             # Shuffle the training data.
-            train_df.sample(frac=1).reset_index(drop=True)
-
-            # Print the ratio of external train vs external test data
-            print('Train: {}\nTest: {}'.format(len(train_df), len(ext_df)))
+            train_df.sample(frac=1)
 
             # Create training and validation sets for fine-tuning.
             sub_val_df = train_df.tail(int(len(train_df) * cfg['FINETUNE']['VAL_SPLIT']))
             sub_train_df = train_df[~train_df['id'].isin(sub_val_df['id'])]
 
-            # Model fine-tuning.
-            print('Fine-tuning...')
+            print('Train: {}\nTest: {}'.format(len(train_df), len(ext_df)))
 
-            # The following code was borrowed from src/models/models.py.
+            # ========== The following code was borrowed from src/models/models.py. ====================================
             # Fine-tune the model
             model_def_fn, preprocessing_fn = get_model(cfg['FINETUNE']['MODEL_DEF'])
 
@@ -531,7 +463,7 @@ class TAAFT:
             class_weight = {0: weight_for_0, 1: weight_for_1}
 
             # Refresh the TensorBoard directory
-            tensorboard_path = cfg_full['TRAIN']['PATHS']['TENSORBOARD']
+            tensorboard_path = os.path.join(cfg_full['TRAIN']['PATHS']['TENSORBOARD'], add_date_to_filename('log'))
             if not os.path.exists(tensorboard_path):
                 os.makedirs(tensorboard_path)
 
@@ -553,7 +485,7 @@ class TAAFT:
 
             # Creating a ModelCheckpoint for saving the model
             save_cp = ModelCheckpoint(os.path.join(model_out_dir, 'model_'
-                                                   + str((num_folds_added + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS'])
+                                                   + str((cur_fold_num + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS'])
                                                    + '_percent_train'),
                                       save_best_only=cfg_full['TRAIN']['SAVE_BEST_ONLY'])
 
@@ -592,50 +524,49 @@ class TAAFT:
             metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
             current_results, _ = get_eval_results(current_model_path, ext_df, metrics)
             trial_results_df = pd.concat([trial_results_df, current_results])
-            props.append((num_folds_added + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS'])
+            props.append((cur_fold_num + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS'])
 
             # If the fine-tuned model now performs well on the test set, terminate the trial early.
             perf_check = check_performance(current_results)
             if perf_check and lazy:
                 break
 
-            # # Remove model if performance not satisfactory.
-            # elif not perf_check:
-            #     rmtree(current_model_path)
-
             gc.collect()
             tf.keras.backend.clear_session()
             del model
 
-            if len(ext_df) < min_test_size:
-                print('EVALUATING PREVIOUS MODELS ON MINIMUM SIZED TEST SET...')
-
-                # Set up column in trial results df to specify whether results are for fixed or variable sized test set.
-                var_size_test_set = [1] * (num_folds_added + 1)
-                # Add an extra 1 in the test set size column. This is for when we evaluated the original (non finetuned)
-                # model on the external dataset.
-                var_size_test_set.append(1)
-
-                # For each previous model, get results on minimum (fixed) size test set.
-                for prev_model in os.listdir(model_out_dir):
-                    prev_model_path = os.path.join(model_out_dir, prev_model)
-                    metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
-                    fixed_test_set_eval, _ = get_eval_results(prev_model_path, ext_df, metrics)
-                    trial_results_df = pd.concat([trial_results_df, fixed_test_set_eval])
-                    var_size_test_set.append(0)
-
-                # Concatenate fixed/variable size test set column with the trial result df.
-                var_size_test_set = pd.DataFrame(var_size_test_set, columns=['variable_sized_test_set'])\
-                    .reset_index(drop=True)
-                props.extend(props)
-                props = pd.DataFrame(props, columns=['ext_data_prop']).reset_index(drop=True)
-                trial_results_df = trial_results_df.reset_index(drop=True)
-                trial_results_df = pd.concat([var_size_test_set, props, trial_results_df], axis=1)
-                trial_results_df.to_csv(os.path.join(trial_folder, 'results.csv'))
+            # ==========================================================================================================
 
             # Update loop counters.
             cur_fold_num += 1
-            num_folds_added += 1
+            props.append(cur_fold_num / cfg['FOLD_SAMPLE']['NUM_FOLDS'])
+
+        print('EVALUATING PREVIOUS MODELS ON MINIMUM SIZED TEST SET...')
+
+        # Set up column in trial results df to specify whether results are for fixed or variable sized test set.
+        var_size_test_set = [1] * (cur_fold_num)
+
+        # Add an extra 1 in the test set size column. This is for when we evaluated the original (non finetuned)
+        # model on the external dataset.
+        var_size_test_set.append(1)
+
+        # For each previous model, get results on minimum (fixed) size test set.
+        for prev_model in os.listdir(model_out_dir):
+            prev_model_path = os.path.join(model_out_dir, prev_model)
+            metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
+            fixed_test_set_eval, _ = get_eval_results(prev_model_path, ext_df, metrics)
+            trial_results_df = pd.concat([trial_results_df, fixed_test_set_eval])
+            var_size_test_set.append(0)
+
+        # Concatenate fixed/variable size test set column with the trial result df.
+        var_size_test_set = pd.DataFrame(var_size_test_set, columns=['variable_sized_test_set']) \
+            .reset_index(drop=True)
+        props.extend(props)
+        props = pd.DataFrame(props, columns=['ext_data_prop']).reset_index(drop=True)
+        trial_results_df = trial_results_df.reset_index(drop=True)
+        trial_results_df = pd.concat([var_size_test_set, props, trial_results_df], axis=1)
+        trial_results_df.to_csv(os.path.join(trial_folder, 'results.csv'))
+
 
     def finetune_multiple_trials(self):
         '''

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -1,16 +1,22 @@
 import gc
 import glob
+import math
 import os
+import argparse
+
 import yaml
 import numpy as np
 import pandas as pd
 import tensorflow as tf
 from sklearn.metrics import confusion_matrix
-from tensorflow.keras.callbacks import EarlyStopping, ModelCheckpoint
+from sklearn.model_selection import StratifiedGroupKFold
+from imblearn.over_sampling import RandomOverSampler
+from tensorflow.keras.callbacks import EarlyStopping
 from tensorflow.keras.metrics import Recall
 from tensorflow.keras.models import load_model
 from tensorflow.keras.optimizers import Adam
 from tensorflow_addons.losses import SigmoidFocalCrossEntropy, sigmoid_focal_crossentropy
+
 from models.models import get_model
 from predict import predict_set
 from src.custom.metrics import Specificity
@@ -21,8 +27,10 @@ from src.preprocessor import MModePreprocessor
 from train import log_train_params
 
 # cfg is the sub-dictionary of the config file pertaining to fine-tuning experiments. cfg_full is the full config file.
-cfg = yaml.full_load(open(os.path.join(os.getcwd(), "config.yml"), 'r'))['EXTERNAL_VAL']
-cfg_full = yaml.full_load(open(os.path.join(os.getcwd(), "config.yml"), 'r'))
+cfg = yaml.full_load(open(os.path.join(os.getcwd(), "config.yml"), 'r'))
+
+SLIDING = 1
+NO_SLIDING = 0
 
 
 def make_scheduler(writer, hparams):
@@ -59,21 +67,12 @@ def write_folds_to_csv(folds, file_path):
     :param folds: List of pd.DataFrames. Each DataFrame is a fold.
     :param file_path: Absolute path where folds should be stored.
     '''
-    # Set up the folds csv.
-    folds_csv = pd.DataFrame([])
-    fold_nums = []
-    i = 1
-    for fold in folds:
-        folds_csv = pd.concat([folds_csv, fold], ignore_index=True)
-        fold_nums.extend([i] * len(fold))
-        i += 1
 
-    # Append to the folds df a column for specifying fold number.
-    fold_nums = pd.DataFrame(fold_nums, columns=['fold_number']).reset_index(drop=True)
-    folds_csv = folds_csv.reset_index(drop=True)
-    folds_csv.columns = ['id']
-    folds_csv = pd.concat([fold_nums, folds_csv], axis=1)
-    folds_csv.to_csv(file_path)
+    folds_df = pd.DataFrame([])
+    for i in range(len(folds)):
+        folds[i].insert(0, 'fold_number', i + 1)
+        folds_df = pd.concat([folds_df, folds[i]], ignore_index=True)
+    folds_df.to_csv(file_path, index=False)
 
 
 def check_performance(df):
@@ -104,13 +103,13 @@ def get_external_clip_df():
     :returns: pd.DataFrame. Stores combined clip information as shown in external db.
     '''
     ext_dfs = []
-    for center in cfg['LOCATIONS']:
-        center_split_path = os.path.join(os.getcwd() + cfg['PATHS']['CSVS_SPLIT'], center)
+    for center in cfg['EXTERNAL_VAL']['LOCATIONS']:
+        center_split_path = os.path.join(os.getcwd() + cfg['EXTERNAL_VAL']['PATHS']['CSVS_SPLIT'], center)
         for csv in ['train.csv', 'val.csv']:
             ext_dfs.append(pd.read_csv(os.path.join(center_split_path, csv)))
     ext_df = pd.concat(ext_dfs, ignore_index=True)
-    labelled_ext_df_path = os.path.join(os.getcwd() + cfg['PATHS']['CSV_OUT'], 'labelled_external_dfs/')
-    if cfg['REFRESH_FOLDERS']:
+    labelled_ext_df_path = os.path.join(os.getcwd() + cfg['EXTERNAL_VAL']['PATHS']['CSV_OUT'], 'labelled_external_dfs/')
+    if cfg['EXTERNAL_VAL']['REFRESH_FOLDERS']:
         refresh_folder(labelled_ext_df_path)
     labelled_ext_df_path += add_date_to_filename('labelled_ext') + '.csv'
     ext_df.to_csv(labelled_ext_df_path)
@@ -118,93 +117,55 @@ def get_external_clip_df():
     return ext_df
 
 
-def get_eval_results(model_path, test_df, metrics, save_pred_labels=True, verbose=True):
+def evaluate_model(model, test_df, preprocessor, base_folder):
     '''
     Returns a df containing evaluation results of the model stored at model_path on test_set, using specified metrics.
-    :param model_path: Absolute path to model.
-    :param test_df: DataFrame on which to evaluate the model.
-    :param metrics: List of metrics for which to report evaluation results.
-    :param verbose: Boolean. If True, prints out test results in list and df form (default value is True).
+    :param model: Model to evaluate; precompiled with proper metrics
+    :param test_df: TF dataset on which to evaluate the model.
+    :param preprocessor: An MMode preprocessor object
+    :param base_folder: Folder in which to log predictions
+    :return: dict of evaluation metrics
     '''
-    # Load and compile model from model_path.
-    model = load_model(model_path, compile=False)
 
-    # Read values from the config file.
-    model_config = cfg_full['TRAIN']['PARAMS']['EFFICIENTNET']
-    lr = cfg['FINETUNE']['LR']
-    optimizer = Adam(learning_rate=lr)
+    test_set = tf.data.Dataset.from_tensor_slices((test_df['filename'].tolist(), test_df['label'].tolist()))
+    preprocessed_test_set = preprocessor.prepare(test_set, test_df, shuffle=False, augment=False)
 
-    # Compile the model using specified list of metrics.
-    model.compile(loss=SigmoidFocalCrossEntropy(reduction=tf.keras.losses.Reduction.AUTO,
-                                                alpha=model_config['ALPHA'],
-                                                gamma=model_config['GAMMA']),
-                  optimizer=optimizer, metrics=metrics)
-    pred_labels, probs = predict_set(model, test_df)
+    test_pred_probs = model.predict(preprocessed_test_set)
+    test_pred_class = np.round(test_pred_probs)
 
-    # Saving prediction labels and probabilities.
-    pred_label_df = None
-    if save_pred_labels:
-        pred_labels_col = pd.DataFrame(pred_labels, columns=['pred_label']).reset_index(drop=True)
-        probs_col = pd.DataFrame(probs, columns=['prob']).reset_index(drop=True)
-        ids = pd.DataFrame(test_df['id'], columns=['id']).reset_index(drop=True)
-        pred_label_df = pd.concat([ids, pred_labels_col, probs_col], axis=1)
+    # Save predictions
+    test_preds_df = test_df[['filename', 'label']]
+    test_preds_df['pred_prob'] = test_pred_probs
+    test_preds_df['pred_class'] = test_pred_class
+    test_preds_df.to_csv(os.path.join(base_folder, 'test_set_preds.csv'), index=False)
 
-    conf_mtrx = confusion_matrix(y_true=test_df['label'], y_pred=np.rint(probs))
-
-    results = []
-    metric_names = []
-
-    for metric in metrics:
-        # Probabilities are stored as floats, while Accuracy metric compares integer values for labels and
-        # probs. Round probabilities to the closer value of 0 or 1.
-        if metric.name == 'Accuracy':
-            probs = np.rint(probs)
-        metric.update_state(test_df['label'], probs)
-        results += [metric.result().numpy()]
-        metric_names += [metric.name]
-
-    # Flatten the confusion matrix into a list storing: [tn, fp, fn, tp].
-    results += [conf_mtrx.ravel()]
-    metric_names += ['confusion_matrix']
-
-    # Create df storing evaluation results.
-    res_df = pd.DataFrame([results], columns=metric_names)
-
-    # Record loss value on external test set.
-    true_labels = np.array(test_df['label']).astype(np.float)
-    loss_value = np.array(sigmoid_focal_crossentropy(y_true=true_labels, y_pred=probs))
-    loss_value = loss_value / len(probs)
-    loss_value = pd.DataFrame([loss_value], columns=['loss'])
-    res_df = pd.concat([loss_value, res_df], axis=1)
-
-    gc.collect()
-    tf.keras.backend.clear_session()
-    del model
-
-    if save_pred_labels == 1:
-        return res_df, pred_label_df
-    return res_df, None
+    # Determine results for metrics
+    test_results = model.evaluate(preprocessed_test_set, return_dict=True)
+    test_results['confusion_matrix'] = str(confusion_matrix(y_true=test_df['label'], y_pred=test_pred_class).ravel())
+    return test_results
 
 
 def setup_experiment(experiment_path=None):
     '''
-    Creates a new experiment folder which contains one subdirectory for each trial in the experiment. The newly
-    created experiment folder is labelled with a Unix timestamp. Returns the path to the newly created experiment.
+    Creates a new experiment folder if no path is supplied, identified with a Unix timestamp. Then creates a
+    subdirectory for a new trial in the experiment. Returns the path to the newly created trial.
     :param experiment_path: Absolute path to folder storing experiments.
     :returns: Absolute path to newly created experiment.
     '''
+
     if experiment_path is None:
-        experiment_folder = os.getcwd() + cfg['PATHS']['EXPERIMENTS']
+        experiment_folder = os.getcwd() + cfg['EXTERNAL_VAL']['PATHS']['EXPERIMENTS']
         experiment_path = os.path.join(experiment_folder, add_date_to_filename('experiment'))
+        os.makedirs(experiment_path)
+    else:
+        assert os.path.exists(experiment_path), f"{experiment_path} does not exist."
 
-    os.makedirs(experiment_path)
-
-    # Create trial folders
-    for trial_num in range(cfg['NUM_TRIALS']):
-        trial_path = os.path.join(experiment_path, 'trial_' + str(trial_num + 1))
-        os.makedirs(trial_path)
-
-    return experiment_path
+    # Create a new trial folder
+    n_existing_trials = len(os.listdir(experiment_path))
+    new_trial_num = n_existing_trials + 1
+    trial_path = os.path.join(experiment_path, f'trial_{new_trial_num}')
+    os.makedirs(trial_path)
+    return trial_path
 
 
 def upsample_absent_sliding_data(train_df, upsample_df, prop, absent_pct, method='gaussian_noise'):
@@ -273,350 +234,234 @@ def upsample_absent_sliding_data(train_df, upsample_df, prop, absent_pct, method
         return train_df, upsample_df
 
 
-# TAAFT stands for: Threshold-Aware Accumulative Fine-Tuner
-class TAAFT:
+def sample_folds(clip_df, trial_folder, k, seed=None):
     '''
-    The TAAFT class encapsulates the implementation of the fine-tuning for generalizability experiments.
-    Handles fold sampling and fine-tuning trials.
+    Samples external data in clip_df into k folds. Attempts to preserve ratio of positive to negative classes in each
+    fold. Folds are saved in a .csv file, where each fold is identified with an integer index, followed by each clip
+    id in the fold
+    :param clip_df: Clip table for all clips in this trial
+    :param trial_folder: Absolute path to folder in which to place folds. Corresponds to a particular trial.
+    :param k: Number of folds
+    :param seed: Random seed for fold sampling
     '''
-    def __init__(self, mini_clip_df, k):
-        '''
-        :param clip_df: DataFrame containing all clip data from external centers.
-        :param k: Number of folds in which to sample data in df by patient id. Note that these folds, while sampled by
-        patient id, are stored by clip id.
-        '''
-        print("CREATING A NEW TAAFT (k = {})".format(k))
-        self.k = k
-        self.mini_clip_df = mini_clip_df
-        np.random.seed(cfg['FOLD_SAMPLE']['SEED'])
-
-    def sample_folds(self, trial_folder):
-        '''
-        Samples external data in self.clip_df into self.k folds. Preserves ratio of positive to negative classes in each
-        fold. Folds are saved in a .txt file, where each fold is identified with an integer index, followed by each clip
-        id in the fold on a new line.
-        :param trial_folder: Absolute path to folder in which to place patient folds. Corresponds to a particular trial.
-        '''
-
-        sliding_df = self.mini_clip_df[self.mini_clip_df['label'] == 1]
-        no_sliding_df = self.mini_clip_df[self.mini_clip_df['label'] == 0]
-
-        # Get unique patient ids.
-        sliding_ids = sliding_df['patient_id'].unique()
-        no_sliding_ids = no_sliding_df['patient_id'].unique()
-
-        print("{} unique sliding patient ids found.".format(len(sliding_ids)))
-        print("{} unique no-sliding patient ids found.\n".format(len(no_sliding_ids)))
-
-        # Shuffle the patient ids.
-        np.random.shuffle(sliding_ids)
-        np.random.shuffle(no_sliding_ids)
-
-        trial_name = trial_folder.split('\\')[-1]
-        folds_path = os.path.join(trial_folder, add_date_to_filename('folds_' + trial_name) + '.csv')
-
-        # Make the file that stores ids by fold if it doesn't already exist.
-        # Clear the file if user intends to overwrite its contents.
-        overwrite = cfg['PARAMS']['OVERWRITE_FOLDS']
-        if not os.path.exists(folds_path):
-            open(folds_path, "x").close()
-        elif overwrite:
-            open(folds_path, "w").close()
-
-        # Keep track of the desired sizes for each fold. Since not all folds will be of the same size in terms
-        # of patient ids, this eliminates the need to dynamically compute each fold size.
-        n_folds = cfg['FOLD_SAMPLE']['NUM_FOLDS']
-        fold_sizes = [len(sliding_ids) // n_folds] * n_folds
-        fold_sizes[-1] += len(sliding_ids) % n_folds
-
-        folds = []
-        sliding_count = [0] * n_folds
-        no_sliding_count = [0] * n_folds
-
-        for i in range(n_folds):
-            fold_end = min(fold_sizes[i], len(sliding_ids))
-            cur_ids = sliding_ids[:fold_end]
-            sliding_ids = sliding_ids[fold_sizes[i]:]
-            cur_fold_sliding = sliding_df[sliding_df['patient_id'].isin(cur_ids)]['id']
-            cur_fold_no_sliding = no_sliding_df[no_sliding_df['patient_id'].isin(cur_ids)]['id']
-            sliding_count[i] += len(cur_fold_sliding)
-            no_sliding_count[i] += len(cur_fold_no_sliding)
-            no_sliding_df = no_sliding_df[~no_sliding_df['patient_id'].isin(cur_ids)]
-            folds.append(pd.concat([cur_fold_sliding, cur_fold_no_sliding]))
-
-        no_sliding_ids = no_sliding_df['patient_id'].values
-        no_sliding_to_add = [0] * n_folds
-        for i in range(len(no_sliding_ids)):
-            no_sliding_to_add[i % n_folds] += 1
-
-        for i in range(n_folds):
-            n_add = no_sliding_to_add[i]
-            folds[i] = pd.concat([folds[i], no_sliding_df.head(n_add)['id']])
-            no_sliding_df = no_sliding_df.tail(len(no_sliding_df) - n_add)
-            no_sliding_count[i] += len(no_sliding_df.head(n_add))
-
-        ratios = []
-        for i in range(n_folds):
-            ratio = no_sliding_count[i] / sliding_count[i]
-            ratios.append(ratio)
-            print('Fold {}: {} sliding, {} no sliding. Absent to present ratio: {}'
-                  .format(i + 1, sliding_count[i], no_sliding_count[i], ratio))
-
-        print('Average absent to present ratio: {}'.format(sum(ratios) / n_folds))
-
-        # Write the folds to the fold file:
-        if cfg['FOLD_SAMPLE']['OVERWRITE_FOLDER']:
-            refresh_folder(os.getcwd() + cfg['PATHS']['FOLDS'])
-        write_folds_to_csv(folds, folds_path)
-
-    def finetune_single_trial(self, trial_folder, hparams=None, lazy=True, upsample=True):
-        '''
-        Performs a single fine-tuning trial. Fine-tunes a model on external clip data, repeatedly augmenting external
-        data slices to a training set until all external data has been used for training.
-        :param trial_folder: Absolute path to folder in which to place metrics for current trial.
-        :param hparams: Specifies the set of hyperparameters for fine-tuning the model.
-        :param lazy: When True, trial will terminate once model performance exceeds minimum thresholds.
-        :param upsample: When True, upsamples absent sliding mini-clips in each training set during fine-tuning.
-        '''
-
-        original_model_path = os.path.join(os.getcwd(), cfg_full['PREDICT']['MODEL'])
-        metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
-
-        # Set up result directories for given trial; read values from config file.
-        model_out_dir = os.path.join(trial_folder, 'models')
-        if not os.path.exists(model_out_dir):
-            os.makedirs(model_out_dir)
-
-        # Set up the labelled external dataframe for augmenting the training data.
-        ext_df = self.mini_clip_df
-
-        # This df will store trial results.
-        trial_results_df = pd.DataFrame([])
-
-        # Get results for original model before fine-tuning.
-        res_df, _ = get_eval_results(original_model_path, ext_df, metrics)
-        trial_results_df = pd.concat([trial_results_df, res_df])
-        original_model = load_model(original_model_path, compile=False)
-        original_model.save(os.path.join(model_out_dir, 'model_0.0_percent_train'))
-
-        model_name = cfg_full['TRAIN']['MODEL_DEF'].lower()
-        hparams = cfg_full['TRAIN']['PARAMS'][model_name.upper()] if hparams is None else hparams
-
-        model_def = cfg_full['TRAIN']['MODEL_DEF'].upper()
-        model_config = cfg_full['TRAIN']['PARAMS'][model_def]
-
-        # Retrieve patient folds (stored by clip ids).
-        filename = glob.glob(os.path.join(trial_folder, 'folds*.csv'))[0]
-        folds = pd.read_csv(filename)
-
-        train_df = pd.DataFrame([])
-
-        # If absent sliding mini-clips are to be upsampled, create a df for saving these upsampled mini-clips.
-        upsample_df = pd.DataFrame([], columns=['ext_data_prop', 'miniclip_id'])
-        upsample_miniclips_path = os.path.join(trial_folder, 'upsample_miniclips.csv')
-
-        min_test_size = int(len(ext_df) * cfg['MIN_TEST_SIZE'])
-
-        cur_fold_num = 0
-        props = [0]
-
-        # Refresh the TensorBoard directory
-        tensorboard_path = os.getcwd() + os.path.join(cfg_full['TRAIN']['PATHS']['TENSORBOARD'],
-                                                      add_date_to_filename('log'))
-        if not os.path.exists(tensorboard_path):
-            os.makedirs(tensorboard_path)
-
-        while len(ext_df) > min_test_size:
-            print('Fine-tuning: {} of {} external data slices...'
-                  .format(cur_fold_num + 1, cfg['FOLD_SAMPLE']['NUM_FOLDS']))
-            fold_to_add = folds[folds['fold_number'] == cur_fold_num + 1]
-            train_df = pd.concat([train_df, ext_df[ext_df['id'].isin(fold_to_add['id'])]])
-            ext_df = ext_df[~ext_df['id'].isin(fold_to_add['id'])]
-
-            # Model starts out as the original model, but then gets fine-tuned.
-            model = load_model(original_model_path, compile=False)
-            metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
-
-            # Freeze some layers.
-            freeze_cutoff = -1 if model_config['BLOCKS_FROZEN'] == 0 else model_config['BLOCKS_FROZEN']
-            for i in range(len(model.layers)):
-                if i <= freeze_cutoff:
-                    model.layers[i].trainable = False
-                # Freeze all batch norm layers
-                elif ('batch' in model.layers[i].name) or ('bn' in model.layers[i].name):
-                    model.layers[i].trainable = False
-
-            # Create training and validation sets for fine-tuning.
-            clips_not_upsampled = train_df[~train_df['id'].isin(upsample_df['miniclip_id'])]
-            val_num = int(len(clips_not_upsampled) * cfg['FINETUNE']['VAL_SPLIT'])
-            sub_val_df = clips_not_upsampled.tail(val_num)
-            sub_train_df = train_df[~train_df['id'].isin(list(sub_val_df['id']))]
-            print(len(sub_val_df[sub_val_df['label'] == 0]), len(sub_train_df[sub_train_df['label'] == 0]))
-            print(len(sub_val_df[sub_val_df['label'] == 1]), len(sub_train_df[sub_train_df['label'] == 1]))
-            print(len(set(sub_train_df['id']) - set(sub_val_df['id'])) == len(sub_train_df['id'].unique()))
-            print(len(set(sub_val_df['id']) - set(sub_train_df['id'])) == len(sub_val_df['id'].unique()))
-
-            if upsample:
-                # cur_ext_prop is the current external data proportion used for training
-                cur_ext_prop = (cur_fold_num + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS']
-                sub_train_df, upsample_df = upsample_absent_sliding_data(sub_train_df, upsample_df, cur_ext_prop, 0.25)
-                train_df = pd.concat([sub_train_df, sub_val_df])
-
-                # Update the upsampled mini-clips .csv file.
-                if os.path.exists(upsample_miniclips_path):
-                    os.remove(upsample_miniclips_path)
-                upsample_df.to_csv(upsample_miniclips_path)
-
-            # Shuffle the training data.
-            train_df.sample(frac=1)
-
-            print('Train: {}\nTest: {}'.format(len(train_df), len(ext_df)))
-
-            # ========== The following code was borrowed from src/models/models.py. ====================================
-            # Fine-tune the model
-            model_def_fn, preprocessing_fn = get_model(cfg['FINETUNE']['MODEL_DEF'])
-
-            # Prepare the training and validation sets from the dataframes.
-            train_set = tf.data.Dataset.from_tensor_slices(
-                (sub_train_df['filename'].tolist(), sub_train_df['label'].tolist()))
-            val_set = tf.data.Dataset.from_tensor_slices(
-                (sub_val_df['filename'].tolist(), sub_val_df['label'].tolist()))
-            test_set = tf.data.Dataset.from_tensor_slices((ext_df['filename'].tolist(), ext_df['label'].tolist()))
-
-            preprocessor = MModePreprocessor(preprocessing_fn)
-
-            # Define the preprocessing pipelines for train, test and validation
-            train_set = preprocessor.prepare(train_set, sub_train_df, shuffle=True, augment=True)
-            val_set = preprocessor.prepare(val_set, sub_val_df, shuffle=False, augment=False)
-            test_set = preprocessor.prepare(test_set, ext_df, shuffle=False, augment=False)
-
-            # Create dictionary for class weights like in src/train.py.
-            num_no_sliding = len(sub_train_df[sub_train_df['label'] == 0])
-            num_sliding = len(sub_train_df[sub_train_df['label'] == 1])
-            total = num_no_sliding + num_sliding
-            weight_for_0 = (1 / num_no_sliding) * (total / 2.0)
-            weight_for_1 = (1 / num_sliding) * (total / 2.0)
-            class_weight = {0: weight_for_0, 1: weight_for_1}
-
-            log_dir = os.path.join(tensorboard_path, 'log_' + str((cur_fold_num + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS']))
-
-            # uncomment line below to include tensorboard profiler in callbacks
-            # basic_call = tf.keras.callbacks.TensorBoard(log_dir=log_dir, histogram_freq=1, profile_batch=1)
-            basic_call = tf.keras.callbacks.TensorBoard(log_dir=log_dir, histogram_freq=1)
-
-            # Learning rate scheduler & logging LR
-            writer1 = tf.summary.create_file_writer(tensorboard_path + '/train')
-
-            scheduler = make_scheduler(writer1, hparams)
-            lr_callback = tf.keras.callbacks.LearningRateScheduler(scheduler)
-
-            # Early stopping
-            early_stopping = EarlyStopping(monitor='val_loss', verbose=1, patience=cfg_full['TRAIN']['PATIENCE'],
-                                           mode='min',
-                                           restore_best_weights=True, min_delta=cfg['FINETUNE']['MIN_DELTA'])
-
-            # Log model params to tensorboard
-            writer2 = tf.summary.create_file_writer(tensorboard_path + '/test')
-            if tensorboard_path is not None:
-                log_train_params(writer1, hparams)
-
-            lr = cfg['FINETUNE']['LR']
-
-            optimizer = Adam(learning_rate=lr)
-            model.compile(loss=SigmoidFocalCrossEntropy(reduction=tf.keras.losses.Reduction.AUTO,
-                                                        alpha=model_config['ALPHA'], gamma=model_config['GAMMA']),
-                          optimizer=optimizer, metrics=metrics)
-
-            # Train and save the model
-            epochs = cfg['FINETUNE']['EPOCHS']
-            history = model.fit(train_set, epochs=epochs, validation_data=val_set,
-                                class_weight=class_weight,
-                                callbacks=[basic_call, early_stopping, lr_callback], verbose=1)
-
-            model.save(os.path.join(model_out_dir, 'model_' + str((cur_fold_num + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS'])
-                                    + '_percent_train'))
-
-            # Log early stopping to tensorboard
-            if history is not None:
-                if len(history.epoch) < epochs:
-                    with writer2.as_default():
-                        tf.summary.text(name='Early Stopping', data=tf.convert_to_tensor('Training stopped early'),
-                                        step=0)
-
-            # Add evaluation results for the current model on the current test set to the trial results df.
-            current_model_path = os.path.join(model_out_dir, os.listdir(model_out_dir)[-1])
-            metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
-            current_results, _ = get_eval_results(current_model_path, ext_df, metrics)
-            trial_results_df = pd.concat([trial_results_df, current_results])
-
-            # If the fine-tuned model now performs well on the test set, terminate the trial early.
-            perf_check = check_performance(current_results)
-            if perf_check and lazy:
-                break
-
-            gc.collect()
-            tf.keras.backend.clear_session()
-            del model
-
-            # ==========================================================================================================
-
-            # Update loop counters.
-            cur_fold_num += 1
-            props.append(cur_fold_num / cfg['FOLD_SAMPLE']['NUM_FOLDS'])
-
-        print('EVALUATING PREVIOUS MODELS ON MINIMUM SIZED TEST SET...')
-
-        # Set up column in trial results df to specify whether results are for fixed or variable sized test set.
-        var_size_test_set = [1] * (cur_fold_num)
-
-        # Add an extra 1 in the test set size column. This is for when we evaluated the original (non finetuned)
-        # model on the external dataset.
-        var_size_test_set.append(1)
-
-        # For each previous model, get results on minimum (fixed) size test set.
-        for prev_model in os.listdir(model_out_dir):
-            prev_model_path = os.path.join(model_out_dir, prev_model)
-            metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
-            fixed_test_set_eval, _ = get_eval_results(prev_model_path, ext_df, metrics)
-            trial_results_df = pd.concat([trial_results_df, fixed_test_set_eval])
-            var_size_test_set.append(0)
-
-        # Concatenate fixed/variable size test set column with the trial result df.
-        var_size_test_set = pd.DataFrame(var_size_test_set, columns=['variable_sized_test_set']) \
-            .reset_index(drop=True)
-        props.extend(props)
-        props = pd.DataFrame(props, columns=['ext_data_prop']).reset_index(drop=True)
-        trial_results_df = trial_results_df.reset_index(drop=True)
-        trial_results_df = pd.concat([var_size_test_set, props, trial_results_df], axis=1)
-        trial_results_df.to_csv(os.path.join(trial_folder, 'unfreeze_last_block_upsample_2.csv'))
-
-
-    def finetune_multiple_trials(self):
-        '''
-        Runs an experiment consisting of multiple trials. Saves results into .csv format and generates plots for the
-        relevant metric results (by default: loss, sensitivity, and specificity) for each trial.
-        '''
-        experiment_path = setup_experiment()
-        for trial in os.listdir(experiment_path):
-            cur_trial_dir = os.path.join(experiment_path, trial)
-            self.sample_folds(cur_trial_dir)
-            self.finetune_single_trial(cur_trial_dir, lazy=cfg['FINETUNE']['LAZY'])
-
-        # Save finetune results to combined result .csv file.
-        # results_path = finetune_results_to_csv(experiment_path)
-        # plot_finetune_results(results_path)
+
+    sgkfold = StratifiedGroupKFold(n_splits=k, shuffle=True, random_state=seed)
+    folds = []
+    for _, fold_idxs in sgkfold.split(clip_df, clip_df['label'], clip_df['patient_id'].astype(str)):
+        next_fold = clip_df.iloc[fold_idxs]
+        folds.append(next_fold)
+        counts = next_fold['label'].value_counts()
+        print(f"Fold {len(folds)}: {counts[1]} sliding, {counts[0]} absent sliding, Fraction of absent = {counts[0]/next_fold.shape[0]}")
+
+    # Save folds for current trial
+    folds_path = os.path.join(trial_folder, 'folds.csv')
+    write_folds_to_csv(folds, folds_path)
+    return folds
+
+
+def restore_model(original_model_path):
+    '''
+    Loads original model weights from disk and compiles it with metrics of interest.
+    :param original_model_path: Path to folder containing the original model weights (in TF SavedModel format)
+    :return: tf.keras model with original weights
+    '''
+
+    original_model = load_model(original_model_path, compile=False)
+
+    metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
+    model_config = cfg['TRAIN']['PARAMS']['EFFICIENTNET']
+    lr = cfg['EXTERNAL_VAL']['FINETUNE']['LR']
+    optimizer = Adam(learning_rate=lr)
+
+    # Compile the model using specified list of metrics.
+    original_model.compile(loss=SigmoidFocalCrossEntropy(reduction=tf.keras.losses.Reduction.AUTO,
+                                                alpha=model_config['ALPHA'],
+                                                gamma=model_config['GAMMA']),
+                  optimizer=optimizer, metrics=metrics)
+    return original_model
+
+
+def finetune_model(original_model_path, base_folder, full_train_df, mmode_preprocessor, hparams, upsample=True, seed=None):
+    '''
+    Fine-tunes the model on a training set.
+    :param original_model_path: Path to SavedModel constituting the original weights
+    :param base_folder: The folder in which logs, models, and train/val splits will be saved
+    :param full_train_df: The training set (before splitting off a validation set)
+    :param mmode_preprocessor: a MModePreprocessor object for preparing batches
+    :param hparams: Model hyperparameters
+    :param upsample: If set to True, upsamples the minority class in the training set according to the configured ratio
+    :param seed: Random seed for fold sampling
+    '''
+
+    # Split dataset into training and validation sets
+    val_split = cfg['EXTERNAL_VAL']['FINETUNE']['VAL_SPLIT']
+    val_strat_group_kfold = StratifiedGroupKFold(n_splits=math.ceil(1. / val_split), shuffle=True, random_state=seed)
+    train_idx, val_idx = val_strat_group_kfold.split(full_train_df, full_train_df['label'], full_train_df['patient_id'].astype(str)).__next__()
+    train_df = full_train_df.iloc[train_idx]
+    val_df = full_train_df.iloc[val_idx]
+
+    # Oversample the minority class in the training set
+    if upsample:
+        minority_ratio = 1. / (1. - cfg['EXTERNAL_VAL']['FINETUNE']['MINORITY_FRAC']) - 1
+        oversampler = RandomOverSampler(sampling_strategy=minority_ratio, random_state=seed)
+        train_df, _ = oversampler.fit_resample(train_df, train_df['label'])
+
+    # Save training and validation sets
+    splits_dir = os.path.join(base_folder, 'splits')
+    if not os.path.exists(splits_dir):
+        os.makedirs(splits_dir)
+    train_df.to_csv(os.path.join(splits_dir, 'train.csv'), index=False)
+    val_df.to_csv(os.path.join(splits_dir, 'val.csv'), index=False)
+    print(f"TRAIN SET: {train_df['label'].value_counts().to_dict()}, VAL_SET: {val_df['label'].value_counts().to_dict()}")
+
+    # Prepare TF datasets
+    train_set = tf.data.Dataset.from_tensor_slices((train_df['filename'].tolist(), train_df['label'].tolist()))
+    train_set = mmode_preprocessor.prepare(train_set, train_df, shuffle=True, augment=True)
+    val_set = tf.data.Dataset.from_tensor_slices((val_df['filename'].tolist(), val_df['label'].tolist()))
+    val_set = mmode_preprocessor.prepare(val_set, val_df, shuffle=False, augment=False)
+
+    # Get class weights for loss weighting
+    counts = train_df['label'].value_counts().to_numpy()
+    weights = train_df.shape[0] / (2.0 * counts)
+    class_weight = {0: weights[0], 1: weights[1]}
+
+    # Set up TensorBoard logs
+    tensorboard_path = os.path.join(base_folder, 'logs')
+    if not os.path.exists(tensorboard_path):
+        os.makedirs(tensorboard_path)
+    tensorboard = tf.keras.callbacks.TensorBoard(log_dir=tensorboard_path, histogram_freq=1)
+    writer = tf.summary.create_file_writer(tensorboard_path + '/train')
+    if tensorboard_path is not None:
+        log_train_params(writer, hparams)
+
+    # Create learning rate scheduler
+    lr_scheduler = make_scheduler(writer, hparams)
+    lr_callback = tf.keras.callbacks.LearningRateScheduler(lr_scheduler)
+
+    # Define early stopping callback
+    early_stopping = EarlyStopping(monitor='val_loss', verbose=1, patience=cfg['TRAIN']['PATIENCE'], mode='min',
+                                   restore_best_weights=True, min_delta=cfg['EXTERNAL_VAL']['FINETUNE']['MIN_DELTA'])
+
+    # Restore weights of original model
+    model = restore_model(original_model_path)
+
+    # Freeze model layers
+    freeze_cutoff = -1 if hparams['LAYERS_FROZEN'] == 0 else hparams['LAYERS_FROZEN']
+    for i in range(freeze_cutoff + 1):
+        model.layers[i].trainable = False
+
+    # Initialize optimizer, metrics, and compile model
+    optimizer = Adam(learning_rate=cfg['EXTERNAL_VAL']['FINETUNE']['LR'])
+    metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
+    model.compile(loss=SigmoidFocalCrossEntropy(reduction=tf.keras.losses.Reduction.AUTO,
+                                                alpha=hparams['ALPHA'], gamma=hparams['GAMMA']),
+                  optimizer=optimizer, metrics=metrics)
+
+    # Fine-tune the model
+    model.fit(train_set, epochs=cfg['EXTERNAL_VAL']['FINETUNE']['EPOCHS'], validation_data=val_set,
+                class_weight=class_weight,
+                callbacks=[tensorboard, early_stopping, lr_callback], verbose=1)
+
+    # Save and return best model's weights
+    model_path = os.path.join(base_folder, f'model')
+    model.save(model_path)
+    return model
+
+
+def TAAFT(clip_df, n_folds, experiment_path=None, seed=None, hparams=None, lazy=True, upsample=True):
+    '''
+    Executes a trial of TAAFT (Threshold-Aware Accumulative Fine-Tuning).
+    Divides clips into random folds, then runs fine-tuning trials with progressively larger training sets. Evaluates
+    each fine-tuned model on remaining data (variable-size test set and fixed-size test set).
+    :param clip_df: A DataFrame consisting of all clips in the dataset on which to fine-tune the model
+    :param experiment_path: Absolute path to folder corresponding to the current experiment
+    :param seed: Random seed for experiment replicability
+    :param hparams: Specifies the set of hyperparameters for fine-tuning the model.
+    :param lazy: When True, trial will terminate once model performance exceeds minimum thresholds.
+    :param upsample: When True, upsamples absent sliding mini-clips in each training set during fine-tuning.
+    '''
+
+    trial_folder = setup_experiment(experiment_path)                    # Set up folder for this trial
+    folds = sample_folds(clip_df, trial_folder, n_folds, seed=seed)     # Randomly sample folds
+
+    # Set global random seed
+    if seed is not None:
+        tf.random.set_seed(seed)
+
+    original_model_path = cfg['PREDICT']['MODEL']
+
+    # This df will store trial results.
+    trial_results_df = pd.DataFrame([])
+
+    # Initialize preprocessor for M-Mode images
+    _, preprocessing_fn = get_model(cfg['EXTERNAL_VAL']['FINETUNE']['MODEL_DEF'])
+    mmode_preprocessor = MModePreprocessor(preprocessing_fn)
+
+    # Define the fixed test set
+    n_folds_fixed_test_set = math.ceil(cfg['EXTERNAL_VAL']['FIXED_TEST_SIZE'] *
+                                       cfg['EXTERNAL_VAL']['FOLD_SAMPLE']['NUM_FOLDS'])
+    fixed_test_df = pd.concat(folds[-n_folds_fixed_test_set:], axis=0)
+
+    # Get model hyperparameters
+    hparams = cfg['TRAIN']['PARAMS'][cfg['TRAIN']['MODEL_DEF'].upper()] if hparams is None else hparams
+
+    # Conduct fine tuning experiments for progressively larger training sets
+    for i in range(0, n_folds - n_folds_fixed_test_set + 1):
+
+        train_frac = i / n_folds
+        base_folder = os.path.join(trial_folder, str(train_frac))
+        os.makedirs(base_folder)
+
+        # Initialize train, variable test, and fixed test sets
+        variable_test_df = pd.concat(folds[i:n_folds], axis=0)
+
+        # Restore the model's weights and fine-tune the model
+        if i == 0:
+            model = restore_model(original_model_path)
+        else:
+            print(f"**** TRAINING RUN {i}: train_frac={train_frac} ****\n" + 100 * '*')
+            train_df = pd.concat(folds[:i])
+            model = finetune_model(original_model_path, base_folder, train_df, mmode_preprocessor, hparams,
+                                   upsample=upsample, seed=seed)
+
+        # Evaluate model on fixed test set
+        results_row = {'variable_sized_test_set': 1, 'train_data_prop': i / n_folds}
+        results_dict = evaluate_model(model, variable_test_df, mmode_preprocessor, base_folder)
+        results_row.update(results_dict)
+        trial_results_df = trial_results_df.append(results_row, ignore_index=True)
+
+        # Evaluate model on variable test set
+        results_row = {'variable_sized_test_set': 0, 'train_data_prop': i / n_folds}
+        results_dict = evaluate_model(model, fixed_test_df, mmode_preprocessor, base_folder)
+        results_row.update(results_dict)
+        trial_results_df = trial_results_df.append(results_dict, ignore_index=True)
+
+        # Relase unused memory and reset the TF session
+        gc.collect()
+        tf.keras.backend.clear_session()
+        del model
+
+    trial_results_df.to_csv(os.path.join(trial_folder, 'metrics.csv'), index=False)
+    return
 
 
 if __name__ == '__main__':
-    # If the generalizability folder has not been created, do this first. Create the subdirectories for each of the
-    # required data types (e.g. raw clips, .npzs, m-modes, etc.)
-    for path in cfg['PATHS']:
-        if not os.path.exists(os.getcwd() + cfg['PATHS'][path]):
-            os.makedirs(os.getcwd() + cfg['PATHS'][path])
 
+    parser = argparse.ArgumentParser(description="Extract mini-clips as npzs")
+    parser.add_argument('--experiment', default=None, type=str)
+    parser.add_argument('--seed', default=None, type=int)
+    args = parser.parse_args()
+
+    # If the generalizability folder has not been created, create the subdirectories for each of the
+    # required data types (e.g. raw clips, .npzs, m-modes, etc.)
+    for path in cfg['EXTERNAL_VAL']['PATHS']:
+        if not os.path.exists(os.getcwd() + cfg['EXTERNAL_VAL']['PATHS'][path]):
+            os.makedirs(os.getcwd() + cfg['EXTERNAL_VAL']['PATHS'][path])
+
+    # Assemble miniclips from all external centres
     external_df = get_external_clip_df()
 
-    # Construct a TAAFT instance with the dataframe.
-    taaft = TAAFT(external_df, cfg['FOLD_SAMPLE']['NUM_FOLDS'])
-    taaft.finetune_multiple_trials()
-
+    # Conduct fine-tuning experiment
+    seed = args.seed if args.seed is not None else cfg['EXTERNAL_VAL']['FOLD_SAMPLE']['SEED']
+    experiment_path = args.experiment
+    TAAFT(external_df, cfg['EXTERNAL_VAL']['FOLD_SAMPLE']['NUM_FOLDS'], experiment_path, seed)

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -99,7 +99,7 @@ def check_performance(df):
     return True
 
 
-def get_external_clip_df(add_chars=False,drop_linear=False):
+def get_external_clip_df(add_groups=False,drop_linear=False):
     '''
     Returns combined df containing results from raw external db pulls for all multi-center study locations.
     :param add_chars: If True, adds meta-data characteristics to dataset for facilitate subgroup analysis.
@@ -116,11 +116,11 @@ def get_external_clip_df(add_chars=False,drop_linear=False):
     ext_df = pd.concat(ext_dfs, ignore_index=True)
 
     # Add data characteristics to dataset to facilitate subgroup analysis
-    if add_chars:
+    if add_groups:
         ext_df['clip_id'] = ext_df.apply(lambda row: row['id'].split('_')[0], axis=1)
         char_df = pd.read_csv(cfg['EXTERNAL_VAL']['PATHS']['DATA_CHARACTERISTICS'])
         char_df.rename(columns={'id':'clip_id'}, inplace=True)
-        chars_to_include = cfg['EXTERNAL_VAL']['DATA_CHARACTERISTICS'].append('clip_id')
+        chars_to_include = cfg['EXTERNAL_VAL']['DATA_CHARACTERISTICS'] + ['clip_id']
         char_df = char_df[chars_to_include]
         ext_df = ext_df.merge(char_df, how='left', on='clip_id')
         ext_df.drop('clip_id', axis=1, inplace=True)
@@ -631,7 +631,7 @@ if __name__ == '__main__':
             os.makedirs(os.path.join(os.getcwd(),cfg['EXTERNAL_VAL']['PATHS'][path]))
 
     # Assemble miniclips from all external centres
-    external_df = get_external_clip_df(add_chars=True, drop_linear=True)
+    external_df = get_external_clip_df(add_groups=True, drop_linear=True)
 
     # Conduct fine-tuning experiment
     seed = args.seed if args.seed is not None else cfg['EXTERNAL_VAL']['FOLD_SAMPLE']['SEED']

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -463,11 +463,6 @@ class TAAFT:
                         tf.summary.text(name='Early Stopping', data=tf.convert_to_tensor('Training stopped early'),
                                         step=0)
 
-            # for metric in history.history.keys():
-            #     if metric in metrics_df.columns:
-            #         metric_values = history.history[metric]
-            #         metrics_df.loc[metric] = sum(metric_values) / len(metric_values)
-
             test_results = model.evaluate(test_set)
             print(test_results)
 

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -151,7 +151,7 @@ def get_eval_results(model_path, test_df, metrics, verbose=True):
                                                 gamma=model_config['GAMMA']),
                   optimizer=optimizer, metrics=metrics)
     pred_labels, probs = predict_set(model, test_df)
-    conf_mtrx = confusion_matrix(y_true=pred_labels, y_pred=np.rint(probs).astype(np.int))
+    conf_mtrx = confusion_matrix(y_true=test_df['label'], y_pred=np.rint(probs).astype(np.int))
 
     results = []
     metric_names = []
@@ -528,6 +528,7 @@ class TAAFT:
 
             # Add evaluation results for the current model on the current test set to the trial results df.
             current_model_path = os.path.join(model_out_dir, os.listdir(model_out_dir)[-1])
+            metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
             current_results = get_eval_results(current_model_path, ext_df, metrics)
             trial_results_df = pd.concat([trial_results_df, current_results])
             props.append((num_folds_added + 1) / cfg['FOLD_SAMPLE']['NUM_FOLDS'])
@@ -557,6 +558,7 @@ class TAAFT:
                 # For each previous model, get results on minimum (fixed) size test set.
                 for prev_model in os.listdir(model_out_dir):
                     prev_model_path = os.path.join(model_out_dir, prev_model)
+                    metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
                     fixed_test_set_eval = get_eval_results(prev_model_path, ext_df, metrics)
                     trial_results_df = pd.concat([trial_results_df, fixed_test_set_eval])
                     var_size_test_set.append(0)
@@ -568,7 +570,7 @@ class TAAFT:
                 props = pd.DataFrame(props, columns=['ext_data_prop']).reset_index(drop=True)
                 trial_results_df = trial_results_df.reset_index(drop=True)
                 trial_results_df = pd.concat([var_size_test_set, props, trial_results_df], axis=1)
-                trial_results_df.to_csv(os.path.join(trial_folder, 'sens_spec_results.csv'))
+                trial_results_df.to_csv(os.path.join(trial_folder, 'sens_spec_results_trial_1.csv'))
 
             # Update loop counters.
             cur_fold_num += 1

--- a/src/external_validation.py
+++ b/src/external_validation.py
@@ -314,7 +314,7 @@ def finetune_model(original_model_path, base_folder, full_train_df, mmode_prepro
     model = freeze_model_layers(model, 220)
 
     # Initialize optimizer, metrics, and compile model
-    optimizer = Adam(learning_rate=cfg['EXTERNAL_VAL']['FINETUNE']['LR'])
+    optimizer = Adam(learning_rate=cfg['EXTERNAL_VAL']['FINETUNE']['LR'] / 10.)
     metrics = [Recall(name='sensitivity'), Specificity(name='specificity')]
     model.compile(loss=SigmoidFocalCrossEntropy(reduction=tf.keras.losses.Reduction.AUTO,
                                                 alpha=hparams['ALPHA'], gamma=hparams['GAMMA']),
@@ -325,17 +325,17 @@ def finetune_model(original_model_path, base_folder, full_train_df, mmode_prepro
                 class_weight=class_weight,
                 callbacks=[tensorboard, lr_callback], verbose=1)
 
-    print("Unfreezing part of base model")
-    freeze_cutoff = -1 if hparams['LAYERS_FROZEN'] == 0 else hparams['LAYERS_FROZEN']
-    if freeze_cutoff > 0:
-        model = freeze_model_layers(model, freeze_cutoff)
-    optimizer = Adam(learning_rate=cfg['EXTERNAL_VAL']['FINETUNE']['LR'] / 10.)
-    model.compile(loss=SigmoidFocalCrossEntropy(reduction=tf.keras.losses.Reduction.AUTO,
-                                                alpha=hparams['ALPHA'], gamma=hparams['GAMMA']),
-                  optimizer=optimizer, metrics=metrics)
-    model.fit(train_set, epochs=cfg['EXTERNAL_VAL']['FINETUNE']['EPOCHS'], validation_data=val_set,
-                class_weight=class_weight, initial_epoch=10,
-                callbacks=[tensorboard, early_stopping, lr_callback], verbose=1)
+    # print("Unfreezing part of base model")
+    # freeze_cutoff = -1 if hparams['LAYERS_FROZEN'] == 0 else hparams['LAYERS_FROZEN']
+    # if freeze_cutoff > 0:
+    #     model = freeze_model_layers(model, freeze_cutoff)
+    # optimizer = Adam(learning_rate=cfg['EXTERNAL_VAL']['FINETUNE']['LR'] / 10.)
+    # model.compile(loss=SigmoidFocalCrossEntropy(reduction=tf.keras.losses.Reduction.AUTO,
+    #                                             alpha=hparams['ALPHA'], gamma=hparams['GAMMA']),
+    #               optimizer=optimizer, metrics=metrics)
+    # model.fit(train_set, epochs=cfg['EXTERNAL_VAL']['FINETUNE']['EPOCHS'], validation_data=val_set,
+    #             class_weight=class_weight, initial_epoch=10,
+    #             callbacks=[tensorboard, early_stopping, lr_callback], verbose=1)
 
     # Save and return best model's weights
     model_path = os.path.join(base_folder, f'model')

--- a/src/make_splits.py
+++ b/src/make_splits.py
@@ -110,6 +110,8 @@ if (s > 1.0) or (train_prop < 0) or (val_prop < 0) or (test_prop < 0):
 
 # CSV paths
 csv_path = os.path.join(os.getcwd(), 'data/', cfg['PREPROCESS']['PATHS']['CSVS_OUTPUT'])
+if cfg['PREPROCESS']['PATHS']['CSVS_OUTPUT'].split('\\')[0] == 'generalizability':
+    csv_path = os.path.join(os.getcwd(), cfg['PREPROCESS']['PATHS']['CSVS_OUTPUT'])
 
 flow = cfg['PREPROCESS']['PARAMS']['FLOW']
 
@@ -149,11 +151,11 @@ else:
     sliding_df = df_splits_two_stream(sliding_df, flow_sliding_df, train_prop, val_prop, test_prop)
     no_sliding_df = df_splits_two_stream(no_sliding_df, flow_no_sliding_df, train_prop, val_prop, test_prop)
 
-# Add label to dataframes. We consider absent lung sliding to be the "positive" class here, hence the label of 1.
-l0 = [0] * len(sliding_df)
-sliding_df['label'] = l0
-l1 = [1] * len(no_sliding_df)
-no_sliding_df['label'] = l1
+# Add label to dataframes.
+l1 = [1] * len(sliding_df)
+sliding_df['label'] = l1
+l0 = [0] * len(no_sliding_df)
+no_sliding_df['label'] = l0
 
 # Add file path to dataframes
 npz_dir = ''
@@ -210,7 +212,7 @@ val_df = final_df[final_df['split']==1]
 test_df = final_df[final_df['split']==2]
 
 # Write each to csv
-csv_dir = cfg['TRAIN']['PATHS']['CSVS']
+csv_dir = os.getcwd() + cfg['TRAIN']['PATHS']['CSVS']
 if not os.path.exists(csv_dir):
     os.makedirs(csv_dir)
 

--- a/src/make_splits.py
+++ b/src/make_splits.py
@@ -149,11 +149,11 @@ else:
     sliding_df = df_splits_two_stream(sliding_df, flow_sliding_df, train_prop, val_prop, test_prop)
     no_sliding_df = df_splits_two_stream(no_sliding_df, flow_no_sliding_df, train_prop, val_prop, test_prop)
 
-# Add label to dataframes
-l1 = [1] * len(sliding_df)
-sliding_df['label'] = l1
-l0 = [0] * len(no_sliding_df)
-no_sliding_df['label'] = l0
+# Add label to dataframes. We consider absent lung sliding to be the "positive" class here, hence the label of 1.
+l0 = [0] * len(sliding_df)
+sliding_df['label'] = l0
+l1 = [1] * len(no_sliding_df)
+no_sliding_df['label'] = l1
 
 # Add file path to dataframes
 npz_dir = ''

--- a/src/make_splits.py
+++ b/src/make_splits.py
@@ -166,12 +166,12 @@ else:
 
 paths1 = []
 for index, row in sliding_df.iterrows():
-    paths1.append(os.path.join(os.getcwd(), 'data/', npz_dir, 'sliding/', row['id'] + '.npz'))
+    paths1.append(os.path.join(os.getcwd(), npz_dir, 'sliding/', row['id'] + '.npz'))
 sliding_df['filename'] = paths1
 
 paths0 = []
 for index, row in no_sliding_df.iterrows():
-    paths0.append(os.path.join(os.getcwd(), 'data/', npz_dir, 'no_sliding/', row['id'] + '.npz'))
+    paths0.append(os.path.join(os.getcwd(), npz_dir, 'no_sliding/', row['id'] + '.npz'))
 no_sliding_df['filename'] = paths0
 
 # Add flow paths if two-stream
@@ -181,12 +181,12 @@ if flow == 'Both':
 
     paths1 = []
     for index, row in sliding_df.iterrows():
-        paths1.append(os.path.join(os.getcwd(), 'data/', npz_dir, 'sliding/', row['id'] + '.npz'))
+        paths1.append(os.path.join(os.getcwd(), npz_dir, 'sliding/', row['id'] + '.npz'))
     sliding_df['flow_filename'] = paths1
 
     paths0 = []
     for index, row in no_sliding_df.iterrows():
-        paths0.append(os.path.join(os.getcwd(), 'data/', npz_dir, 'no_sliding/', row['id'] + '.npz'))
+        paths0.append(os.path.join(os.getcwd(),  npz_dir, 'no_sliding/', row['id'] + '.npz'))
     no_sliding_df['flow_filename'] = paths0
 
 # Duplicate the no_sliding_df until it's approximately the same size as sliding_df, if desired

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -32,6 +32,8 @@ from tensorflow.keras.applications.efficientnet import EfficientNetB0 as Efficie
 from tensorflow.keras.applications.efficientnet import preprocess_input as efficientnet_preprocess
 import tensorflow_addons as tfa
 
+from src.custom.layers import ToGrayscale
+
 cfg = yaml.full_load(open(os.path.join(os.getcwd(), 'config.yml'), 'r'))
 
 
@@ -767,10 +769,11 @@ def efficientnet(model_config, input_shape, metrics, class_counts):
     l2_reg = model_config['L2_REG']
     fc0_nodes = model_config['FC0_NODES']
 
-    freeze_cutoff = -1 if model_config['BLOCKS_FROZEN'] == 0 else model_config['BLOCKS_FROZEN']
+    freeze_cutoff = -1 if model_config['LAYERS_FROZEN'] == 0 else model_config['LAYERS_FROZEN']
 
     X_input = Input(input_shape, name='input')
-    base_model = EfficientNet(include_top=False, weights='imagenet', input_shape=input_shape, input_tensor=X_input)
+    X_gray = ToGrayscale(name='to_grayscale')(X_input)
+    base_model = EfficientNet(include_top=False, weights='imagenet', input_shape=input_shape, input_tensor=X_gray)
 
     output_bias = None
     kernel_init = model_config['WEIGHT_INITIALIZER']

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -772,8 +772,7 @@ def efficientnet(model_config, input_shape, metrics, class_counts):
     freeze_cutoff = -1 if model_config['LAYERS_FROZEN'] == 0 else model_config['LAYERS_FROZEN']
 
     X_input = Input(input_shape, name='input')
-    X_gray = ToGrayscale(name='to_grayscale')(X_input)
-    base_model = EfficientNet(include_top=False, weights='imagenet', input_shape=input_shape, input_tensor=X_gray)
+    base_model = EfficientNet(include_top=False, weights='imagenet', input_shape=input_shape, input_tensor=X_input)
 
     output_bias = None
     kernel_init = model_config['WEIGHT_INITIALIZER']

--- a/src/preprocessor.py
+++ b/src/preprocessor.py
@@ -470,8 +470,8 @@ class MModePreprocessor:
     From which m-mode reconstructions will be assembled and used as inputs
     '''
 
-    def __init__(self, preprocessing_fn):
-        self.batch_size = cfg['TRAIN']['PARAMS']['BATCH_SIZE']
+    def __init__(self, preprocessing_fn, batch_size=None):
+        self.batch_size = cfg['TRAIN']['PARAMS']['BATCH_SIZE'] if batch_size is None else batch_size
         self.autotune = tf.data.AUTOTUNE
         self.preprocessing_fn = preprocessing_fn
 


### PR DESCRIPTION
This PR contains: 
1. A re-vamp/re-design of a single trial of the "cucumber" method
- external_validation.py now runs a single trial, not an entire experiment (5 trials), for which you can manually specify the seed for splitting the dataset into folds (facilitates reproducibility).
2. The option to upsample from the minority class by generating more than 1 m-mode from each clip during pre-processing
3. Functionality for mid-training subgroup analysis (stratifying metrics by center, probe type, sex, etc.)
4. Updated functionality for plotting summarized and stratified finetuning results (in finetune_results_utils.py)